### PR TITLE
✨ feat : 게시글, 좋아요 기능 1차 구현하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,12 @@ dependencies {
     // S3 관련
     implementation 'software.amazon.awssdk:s3:2.19.1'
 
+    /// QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     /// 보안 관련
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -57,4 +63,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+clean {
+    delete file('src/main/generated')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // S3 관련
+    implementation 'software.amazon.awssdk:s3:2.19.1'
+
     /// 보안 관련
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    /// 스웨거
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
     /// 테스트 의존성
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/ktb/docker-compose-ktb.yml
+++ b/ktb/docker-compose-ktb.yml
@@ -1,0 +1,22 @@
+services:
+
+  mysql:
+    image: mysql:8.0
+    container_name: ktb-mysql
+    volumes:
+      - ./mysql/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./mysql/data:/var/lib/mysql
+    ports:
+      - '3306:3306'
+    environment:
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+
+  # Redis
+  redis:
+    image: redis:7.2.5
+    container_name: ktb-redis
+    ports:
+      - '6379:6379'

--- a/ktb/mysql/conf.d/my.cnf
+++ b/ktb/mysql/conf.d/my.cnf
@@ -1,0 +1,10 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
+[mysqld]
+character-set-client-handshake = FALSE
+character-set-server           = utf8mb4
+collation-server               = utf8mb4_unicode_ci

--- a/src/main/java/bootcamp/kakao/community/common/config/AwsS3Config.java
+++ b/src/main/java/bootcamp/kakao/community/common/config/AwsS3Config.java
@@ -1,0 +1,59 @@
+package bootcamp.kakao.community.common.config;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@RequiredArgsConstructor
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String accessSecret;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * Pre signed URL을 만들기 위한 S3Presigner
+     */
+    @Bean
+    public S3Presigner s3Presigner() {
+        if (accessKey == null || accessSecret == null || region == null) {
+            throw new IllegalStateException(ErrorCode.INTERNAL_S3_ERROR.getMessage());
+        }
+
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    /**
+     * 파일 삭제 등 객체 관리를 위한 S3Client 빈 생성
+     */
+    @Bean
+    public S3Client s3Client() {
+        if (accessKey == null || accessSecret == null || region == null) {
+            throw new IllegalStateException(ErrorCode.INTERNAL_S3_ERROR.getMessage());
+        }
+
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/config/LocalSwaggerConfig.java
+++ b/src/main/java/bootcamp/kakao/community/common/config/LocalSwaggerConfig.java
@@ -1,0 +1,47 @@
+package bootcamp.kakao.community.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+@Configuration
+public class LocalSwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("KTB Community Swagger")
+                .description("카카오테크 부트캠프 커뮤니티 스웨거입니다.")
+                .version("1.0.0");
+    }
+
+    /// 필요없는 스키마 제거
+    @Bean
+    public OpenApiCustomizer removeGenericSchemas() {
+        return openApi -> {
+            openApi.getComponents().getSchemas().keySet().removeIf(name ->
+                    name.contains("ApiResponse") || name.contains("SliceResponse")
+            );
+        };
+    }
+
+    /// 스키마 이름 기준 오름차순
+    @Bean
+    public OpenApiCustomizer sortSchemasAlphabetically() {
+        return openApi -> {
+            Map<String, Schema> schemas = openApi.getComponents().getSchemas();
+            openApi.getComponents().setSchemas(new TreeMap<>(schemas));
+        };
+    }
+}

--- a/src/main/java/bootcamp/kakao/community/common/config/QuerydslConfig.java
+++ b/src/main/java/bootcamp/kakao/community/common/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package bootcamp.kakao.community.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/ApiResponse.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/ApiResponse.java
@@ -31,6 +31,11 @@ public record ApiResponse<T>(
         return new ApiResponse<>(HttpStatus.CREATED, true, HttpStatus.CREATED.value(), "성공적으로 생성되었습니다.", null, null);
     }
 
+    // 생성 성공 응답 (201 Created)
+    public static <T> ApiResponse<T> created(final T data) {
+        return new ApiResponse<>(HttpStatus.CREATED, true, HttpStatus.CREATED.value(), "성공적으로 생성되었습니다.", data, null);
+    }
+
     // 수정 성공 응답 (204 No Content)
     public static <T> ApiResponse<T> updated() {
         return new ApiResponse<>(HttpStatus.NO_CONTENT, true, HttpStatus.NO_CONTENT.value(), "성공적으로 수정되었습니다.", null, null);

--- a/src/main/java/bootcamp/kakao/community/common/response/ErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/ErrorCode.java
@@ -69,8 +69,9 @@ public enum ErrorCode {
     // 500 Internal Server Error
     // ========================
     INTERNAL_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
-    BAD_PARAMETER(999, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다."),
-    ;
+    INTERNAL_S3_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 설정이 잘못되었습니다. 속성을 확인하세요."),
+    INTERNAL_S3_URL_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 PreSignedURL 설정이 잘못되었습니다. 속성을 확인하세요."),
+    BAD_PARAMETER(999, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다.");
 
 
     /**

--- a/src/main/java/bootcamp/kakao/community/common/response/paging/SliceRequest.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/paging/SliceRequest.java
@@ -1,9 +1,14 @@
 package bootcamp.kakao.community.common.response.paging;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record SliceRequest(
+
+        @Schema(description = "마지막 ID", example = "null")
         Long lastId,
+
+        @Schema(description = "조회할 개수", example = "10")
         int offSet) {
 }

--- a/src/main/java/bootcamp/kakao/community/common/response/paging/SliceRequest.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/paging/SliceRequest.java
@@ -1,0 +1,9 @@
+package bootcamp.kakao.community.common.response.paging;
+
+import lombok.Builder;
+
+@Builder
+public record SliceRequest(
+        Long lastId,
+        int offSet) {
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/paging/SliceResponse.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/paging/SliceResponse.java
@@ -1,0 +1,5 @@
+package bootcamp.kakao.community.common.response.paging;
+
+public record SliceResponse<T>() {
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/paging/SliceResponse.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/paging/SliceResponse.java
@@ -1,5 +1,19 @@
 package bootcamp.kakao.community.common.response.paging;
 
-public record SliceResponse<T>() {
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
+@Builder
+public record SliceResponse<T>(
+        List<T> content,
+        boolean hasNext
+) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return SliceResponse.<T>builder()
+                .content(slice.getContent())
+                .hasNext(slice.hasNext())
+                .build();
+    }
 }

--- a/src/main/java/bootcamp/kakao/community/common/util/ImageUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/util/ImageUtil.java
@@ -1,0 +1,22 @@
+package bootcamp.kakao.community.common.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class ImageUtil {
+
+    /// 파일 이름을 고유하게 생성하는 메서드
+    public String generateKey(String file) {
+
+        /// 랜덤 UUID
+        String key = UUID.randomUUID().toString();
+
+        /// 확장자 처리
+        String extension = file.substring(file.lastIndexOf(".") + 1);
+
+        return key + "." + extension;
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/util/KeyUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/util/KeyUtil.java
@@ -7,6 +7,11 @@ public class KeyUtil {
 
     /// 개별 키 목록
     private static final String SEPARATOR = ":";
+    private static final String DELIMITER = "-";
+
+    /// 게시글
+    private static final String POST = "post";
+    private static final String VIEW = "view";
 
     /// JWT
     public static final String REFRESH_TOKEN = "refresh_token";
@@ -20,7 +25,10 @@ public class KeyUtil {
     /// 키 생성 함수
     public static String getRefreshTokenKey(Long userId, String deviceType) {
         return REFRESH_TOKEN + SEPARATOR + userId + SEPARATOR + deviceType;
+    }
 
+    public static String getPostView(Long postId) {
+        return POST + DELIMITER + VIEW + SEPARATOR + postId;
     }
 
 

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -9,6 +9,7 @@ import bootcamp.kakao.community.platform.user.application.UserUseCase;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.NoSuchElementException;
@@ -25,6 +26,7 @@ public class ImageService implements ImageUseCase {
 
     /// 게시글 이미지 처리
     @Override
+    @Transactional
     public ImageResponse upload(ImageRequest req, Long userId) throws IOException {
 
         /// 요청한 유저
@@ -42,6 +44,7 @@ public class ImageService implements ImageUseCase {
 
     /// 회원가입을 위한 임시 사용
     @Override
+    @Transactional
     public ImageResponse uploadTemporaryImage(ImageRequest req) throws IOException {
 
         /// 클라우드 요청
@@ -52,6 +55,15 @@ public class ImageService implements ImageUseCase {
         repository.save(image);
 
         return presignedURL;
+    }
+
+    /// URL 바탕으로 이미지 객체 조회하기
+    @Override
+    @Transactional(readOnly = true)
+    public Image getImage(String url) {
+
+        return repository.findByUrl(url)
+                .orElseThrow(NoSuchElementException::new);
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -34,7 +34,7 @@ public class ImageService implements ImageUseCase {
     public ImageResponse upload(ImageRequest req, Long userId) throws IOException {
 
         /// 요청한 유저
-        User user = userService.loadUser(userId).orElseThrow(NoSuchElementException::new);
+        User user = userService.loadUser(userId);
 
         /// 클라우드 요청
         ImageResponse presignedURL = cloudService.getUploadPresignedURL(req.file());
@@ -53,7 +53,7 @@ public class ImageService implements ImageUseCase {
     public List<ImageResponse> upload(List<ImageRequest> req, Long userId) throws IOException {
 
         /// 요청한 유저
-        User user = userService.loadUser(userId).orElseThrow(NoSuchElementException::new);
+        User user = userService.loadUser(userId);
 
         /// 요청한 이미지 목록 추출
         List<String> reqImages = req.stream()

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -34,7 +34,7 @@ public class ImageService implements ImageUseCase {
     public ImageResponse upload(ImageRequest req, Long userId) throws IOException {
 
         /// 요청한 유저
-        User user = userService.getUser(userId).orElseThrow(NoSuchElementException::new);
+        User user = userService.loadUser(userId).orElseThrow(NoSuchElementException::new);
 
         /// 클라우드 요청
         ImageResponse presignedURL = cloudService.getUploadPresignedURL(req.file());
@@ -53,7 +53,7 @@ public class ImageService implements ImageUseCase {
     public List<ImageResponse> upload(List<ImageRequest> req, Long userId) throws IOException {
 
         /// 요청한 유저
-        User user = userService.getUser(userId).orElseThrow(NoSuchElementException::new);
+        User user = userService.loadUser(userId).orElseThrow(NoSuchElementException::new);
 
         /// 요청한 이미지 목록 추출
         List<String> reqImages = req.stream()

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -12,7 +12,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +28,7 @@ public class ImageService implements ImageUseCase {
     /// 의존성
     private final UserUseCase userService;
 
-    /// 게시글 이미지 처리
+    /// 한 장의 이미지 처리
     @Override
     @Transactional
     public ImageResponse upload(ImageRequest req, Long userId) throws IOException {
@@ -39,10 +43,38 @@ public class ImageService implements ImageUseCase {
         Image image = Image.of(user, req.file(), presignedURL.preSignedUrl());
         repository.save(image);
 
+        /// 리턴
         return presignedURL;
     }
 
-    /// 회원가입을 위한 임시 사용
+    /// 여러개의 이미지 처리
+    @Override
+    @Transactional
+    public List<ImageResponse> upload(List<ImageRequest> req, Long userId) throws IOException {
+
+        /// 요청한 유저
+        User user = userService.getUser(userId).orElseThrow(NoSuchElementException::new);
+
+        /// 요청한 이미지 목록 추출
+        List<String> reqImages = req.stream()
+                .map(ImageRequest::file)
+                .toList();
+
+        /// 클라우드 요청
+        List<ImageResponse> presignedURLs = cloudService.getUploadPresignedURL(reqImages);
+
+        /// 객체 저장
+        List<Image> images = presignedURLs.stream()
+                .map(p -> Image.of(user, p.fileName(), p.preSignedUrl()))
+                .toList();
+        repository.saveAll(images);
+
+        /// 리턴
+        return presignedURLs;
+    }
+
+    /// 회원가입을 위한 한 장의 이미지 임시 처리
+    /// 추후, 확정을 지어야한다.
     @Override
     @Transactional
     public ImageResponse uploadTemporaryImage(ImageRequest req) throws IOException {
@@ -54,6 +86,7 @@ public class ImageService implements ImageUseCase {
         Image image = Image.temporaryOf(req.file(), presignedURL.preSignedUrl());
         repository.save(image);
 
+        /// 리턴
         return presignedURL;
     }
 
@@ -64,6 +97,24 @@ public class ImageService implements ImageUseCase {
 
         return repository.findByUrl(url)
                 .orElseThrow(NoSuchElementException::new);
+    }
+
+    /// URL 목록 바탕으로 이미지 배열 객체 조회하기
+    @Override
+    public List<Image> getImage(List<String> urls) {
+
+        /// 값 가져오기
+        List<Image> images = repository.findAllByUrlIn(urls);
+
+        /// Map 변환해서 순서 재정렬
+        Map<String, Image> imageMap = images.stream()
+                .collect(Collectors.toMap(Image::getUrl, i -> i));
+
+        /// List 제공
+        return urls.stream()
+                .map(url -> imageMap.getOrDefault(url, null))
+                .filter(Objects::nonNull)
+                .toList();
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -1,9 +1,57 @@
 package bootcamp.kakao.community.platform.images.image.application;
 
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
+import bootcamp.kakao.community.platform.images.image.domain.repository.ImageRepository;
+import bootcamp.kakao.community.platform.images.image.external.ImageCloudUseCase;
+import bootcamp.kakao.community.platform.user.application.UserUseCase;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
-public class ImageService implements ImageUseCase{
+public class ImageService implements ImageUseCase {
+
+    private final ImageCloudUseCase cloudService;
+    private final ImageRepository repository;
+
+    /// 의존성
+    private final UserUseCase userService;
+
+    /// 게시글 이미지 처리
+    @Override
+    public ImageResponse upload(ImageRequest req, Long userId) throws IOException {
+
+        /// 요청한 유저
+        User user = userService.getUser(userId).orElseThrow(NoSuchElementException::new);
+
+        /// 클라우드 요청
+        ImageResponse presignedURL = cloudService.getUploadPresignedURL(req.file());
+
+        /// 객체 저장
+        Image image = Image.of(user, req.file(), presignedURL.preSignedUrl());
+        repository.save(image);
+
+        return presignedURL;
+    }
+
+    /// 회원가입을 위한 임시 사용
+    @Override
+    public ImageResponse uploadTemporaryImage(ImageRequest req) throws IOException {
+
+        /// 클라우드 요청
+        ImageResponse presignedURL = cloudService.getUploadPresignedURL(req.file());
+
+        /// 객체 저장
+        Image image = Image.temporaryOf(req.file(), presignedURL.preSignedUrl());
+        repository.save(image);
+
+        return presignedURL;
+    }
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
@@ -2,6 +2,7 @@ package bootcamp.kakao.community.platform.images.image.application;
 
 import bootcamp.kakao.community.platform.images.image.application.dto.ImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
 
 import java.io.IOException;
 
@@ -13,4 +14,7 @@ public interface ImageUseCase {
     /// 회원가입을 위한 임시 저장소
     ImageResponse uploadTemporaryImage(ImageRequest req) throws IOException;
 
+
+    /// 내부 서비스 로직
+    Image getImage(String url);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
@@ -5,16 +5,24 @@ import bootcamp.kakao.community.platform.images.image.application.dto.ImageRespo
 import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface ImageUseCase {
 
     /// 사진 저장하기
     ImageResponse upload(ImageRequest req, Long userId) throws IOException;
 
+    /// 여러 사진 저장하기
+    List<ImageResponse> upload(List<ImageRequest> req, Long userId) throws IOException;
+
     /// 회원가입을 위한 임시 저장소
     ImageResponse uploadTemporaryImage(ImageRequest req) throws IOException;
 
 
-    /// 내부 서비스 로직
+    /// 외부 서비스에서 사용할 로직
+    /// 단일 이미지 가져오기
     Image getImage(String url);
+
+    /// 여러개 이미지 가져오기
+    List<Image> getImage(List<String> urls);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
@@ -1,4 +1,16 @@
 package bootcamp.kakao.community.platform.images.image.application;
 
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+
+import java.io.IOException;
+
 public interface ImageUseCase {
+
+    /// 사진 저장하기
+    ImageResponse upload(ImageRequest req, Long userId) throws IOException;
+
+    /// 회원가입을 위한 임시 저장소
+    ImageResponse uploadTemporaryImage(ImageRequest req) throws IOException;
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageRequest.java
@@ -1,4 +1,5 @@
 package bootcamp.kakao.community.platform.images.image.application.dto;
 
-public record ImageRequest() {
+public record ImageRequest(
+        String file) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageResponse.java
@@ -1,5 +1,22 @@
 package bootcamp.kakao.community.platform.images.image.application.dto;
 
-public record ImageResponse() {
-    
+import lombok.Builder;
+
+/**
+ * S3 이미지 DTO
+ * @param fileName      원본 파일 이름
+ * @param preSignedUrl  저장할 S3 주소
+ */
+@Builder
+public record ImageResponse(
+        String fileName,
+        String preSignedUrl) {
+
+    /// 정적 팩토리 메서드
+    public static ImageResponse from(String fileName, String preSignedUrl) {
+        return ImageResponse.builder()
+                .fileName(fileName)
+                .preSignedUrl(preSignedUrl)
+                .build();
+    }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/domain/entity/Image.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/domain/entity/Image.java
@@ -25,7 +25,7 @@ public class Image extends BaseTimeEntity {
     @Column(nullable = false)
     private String fileName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1000)
     private String url;
 
     @Column(nullable = false)

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/domain/entity/Image.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/domain/entity/Image.java
@@ -19,7 +19,7 @@ public class Image extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = true)
     private User user;
 
     @Column(nullable = false)
@@ -28,12 +28,16 @@ public class Image extends BaseTimeEntity {
     @Column(nullable = false)
     private String url;
 
+    @Column(nullable = false)
+    private boolean isConfirmed = false;
+
     /// 생성자
     @Builder
     protected Image(User user, String fileName, String url) {
         this.user = user;
         this.fileName = fileName;
         this.url = url;
+        this.isConfirmed = false;
     }
 
     /// 정적 팩토리 메서드
@@ -43,6 +47,34 @@ public class Image extends BaseTimeEntity {
                 .fileName(fileName)
                 .url(url)
                 .build();
+    }
+
+    /// 임시 생성 정적 팩토리 메서드
+    public static Image temporaryOf(String fileName, String url) {
+        return Image.builder()
+                .user(null)
+                .fileName(fileName)
+                .url(url)
+                .build();
+    }
+
+
+    /// 비즈니스 로직
+    // 사용한다고 확정하는 메서드
+    public void confirm(User user) {
+        this.user = user;
+        this.isConfirmed = true;
+    }
+
+    // 사용한다고 확정하는 메서드
+    public void confirm() {
+
+        /// 예외처리
+        if (this.user == null) {
+            throw new IllegalStateException("사용자 정보가 없는 이미지는 확정할 수 없습니다.");
+        }
+
+        this.isConfirmed = true;
     }
 
 

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/domain/entity/Image.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/domain/entity/Image.java
@@ -77,5 +77,18 @@ public class Image extends BaseTimeEntity {
         this.isConfirmed = true;
     }
 
+    // 사용을 취소하는 메서드
+    public void unConfirm() {
+
+        /// 예외처리
+        if (this.user == null) {
+            throw new IllegalStateException("사용자 정보가 없는 이미지는 취소할 수 없습니다.");
+        }
+
+        /// 사용중이던 것만 취소 가능
+        if (this.isConfirmed) {
+            this.isConfirmed = false;
+        }
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/domain/repository/ImageRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/domain/repository/ImageRepository.java
@@ -3,5 +3,8 @@ package bootcamp.kakao.community.platform.images.image.domain.repository;
 import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByUrl(String url);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/domain/repository/ImageRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/domain/repository/ImageRepository.java
@@ -4,7 +4,12 @@ import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
-
+import java.util.List;
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    /// URL 바탕으로 조회
     Optional<Image> findByUrl(String url);
+
+    /// 여러개 URL 바탕으로 조회
+    List<Image> findAllByUrlIn(List<String> urls);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/external/ImageCloudUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/external/ImageCloudUseCase.java
@@ -1,0 +1,22 @@
+package bootcamp.kakao.community.platform.images.image.external;
+
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface ImageCloudUseCase {
+
+    /// 파일 저장을 위한 presignedURL 제공
+    ImageResponse getUploadPresignedURL(String file) throws IOException;
+
+    /// 파일 저장을 위한 presignedURL 제공
+    List<ImageResponse> getUploadPresignedURL(List<String> files) throws IOException;
+
+    /// 파일 삭제
+    void deleteFile(String file) throws IOException;
+
+    /// 파일 삭제
+    void deleteFile(List<String> files) throws IOException;
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/external/S3Util.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/external/S3Util.java
@@ -1,0 +1,108 @@
+package bootcamp.kakao.community.platform.images.image.external;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.util.ImageUtil;
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class S3Util implements ImageCloudUseCase {
+
+    @Value("${cloud.aws.S3.bucket}")
+    private String bucketName;
+
+    /// PreSignedURL을 위한 s3Presigner
+    private final S3Presigner s3Presigner;
+
+    /// 삭제를 위한 S3Client
+    private final S3Client s3Client;
+
+    /// 이미지 생성
+    private final ImageUtil imageUtil;
+
+    /**
+     * S3에 하나의 파일 저장
+     * @param file  저장할 이미지 파일 이름
+     */
+    @Override
+    public ImageResponse getUploadPresignedURL(String file) throws IOException {
+
+        /// 파일명 수정
+        String key = imageUtil.generateKey(file);
+
+        /// 파일 DTO 생성
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
+                req -> req.signatureDuration(Duration.ofMinutes(15)) /// 15분 유효기간
+                        .putObjectRequest(
+                                PutObjectRequest.builder()
+                                        .bucket(bucketName)
+                                        .key(key)
+                                        .build()
+                        )
+        );
+        String presignedUrl = presignedRequest.url().toString();
+        return ImageResponse.from(file, presignedUrl);
+    }
+
+    /**
+     * S3에 여러개의 파일 저장
+     * @param files  저장할 이미지 파일들 이름
+     */
+    @Override
+    public List<ImageResponse> getUploadPresignedURL(List<String> files) {
+        return files.stream()
+                .map(file -> {
+                    try {
+                        return getUploadPresignedURL(file);
+                    } catch (IOException e) {
+                        throw new IllegalStateException(ErrorCode.INTERNAL_S3_URL_ERROR.getMessage());
+                    }
+                })
+                .toList();
+    }
+
+
+    /**
+     * 이미지 삭제하기
+     * @param fileName  S3에서 삭제할 이미지 이름
+     */
+    @Override
+    public void deleteFile(String fileName) {
+
+        /// 삭제할 오브젝트 생성
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+
+        /// 삭제 요청
+        s3Client.deleteObject(request);
+    }
+
+    /**
+     * 이미지 삭제하기
+     * @param fileNames  S3에서 삭제할 이미지 여러 개
+     */
+    @Override
+    public void deleteFile(List<String> fileNames) {
+
+        /// 반복해서 삭제
+        for (String fileName : fileNames) {
+            deleteFile(fileName);
+        }
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/ImageApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/ImageApi.java
@@ -4,6 +4,7 @@ import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.platform.images.image.application.ImageUseCase;
 import bootcamp.kakao.community.platform.images.image.application.dto.ImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+import bootcamp.kakao.community.platform.images.image.presentation.swagger.ImageApiSpec;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +12,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/images")
 @RequiredArgsConstructor
-public class ImageApi {
+public class ImageApi implements ImageApiSpec {
 
     private final ImageUseCase service;
 
@@ -23,12 +25,12 @@ public class ImageApi {
      * 파일 업로드용 URL 발급
      */
     @PostMapping
-    public ApiResponse<ImageResponse> upload(
-            @RequestBody @Valid ImageRequest request,
+    public ApiResponse<List<ImageResponse>> upload(
+            @RequestBody @Valid List<ImageRequest> request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException {
 
         /// 서비스
-        ImageResponse response = service.upload(request, customUserDetails.getId());
+        List<ImageResponse> response = service.upload(request, customUserDetails.getId());
 
         /// 응답 리턴
         return ApiResponse.created(response);
@@ -36,7 +38,7 @@ public class ImageApi {
 
 
     /**
-     * 회원가입에서 사용하는 업로드용 URL 발급
+     * 회원가입에서 사용하는 단일 업로드용 URL 발급
      */
     @PostMapping("/temp")
     public ApiResponse<ImageResponse> tempUpload(

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/ImageApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/ImageApi.java
@@ -1,9 +1,16 @@
 package bootcamp.kakao.community.platform.images.image.presentation;
 
+import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.platform.images.image.application.ImageUseCase;
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/v1/images")
@@ -12,5 +19,34 @@ public class ImageApi {
 
     private final ImageUseCase service;
 
+    /**
+     * 파일 업로드용 URL 발급
+     */
+    @PostMapping
+    public ApiResponse<ImageResponse> upload(
+            @RequestBody @Valid ImageRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException {
+
+        /// 서비스
+        ImageResponse response = service.upload(request, customUserDetails.getId());
+
+        /// 응답 리턴
+        return ApiResponse.created(response);
+    }
+
+
+    /**
+     * 회원가입에서 사용하는 업로드용 URL 발급
+     */
+    @PostMapping("/temp")
+    public ApiResponse<ImageResponse> tempUpload(
+            @RequestBody @Valid ImageRequest request) throws IOException {
+
+        /// 서비스
+        ImageResponse response = service.uploadTemporaryImage(request);
+
+        /// 응답 리턴
+        return ApiResponse.created(response);
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/swagger/ImageApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/swagger/ImageApiSpec.java
@@ -1,0 +1,34 @@
+package bootcamp.kakao.community.platform.images.image.presentation.swagger;
+
+import bootcamp.kakao.community.common.response.ApiResponse;
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.io.IOException;
+import java.util.List;
+
+@Tag(name = "이미지 API", description = "이미지 발급을 위한 API 입니다.")
+public interface ImageApiSpec {
+
+    @Operation(
+            summary = "파일 업로드용 URL 발급 API",
+            description = "여러개의 파일의 URL 발급 받습니다."
+    )
+    ApiResponse<List<ImageResponse>> upload(
+            @RequestBody @Valid List<ImageRequest> request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException;
+
+
+    @Operation(
+            summary = "회원가입용 임시 파일 업로드용 URL API",
+            description = "회원가입 용으로 임시 파일을 업로드할 수 있습니다."
+    )
+    ApiResponse<ImageResponse> tempUpload(
+            @RequestBody @Valid ImageRequest request) throws IOException;
+}

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
@@ -6,6 +6,7 @@ import bootcamp.kakao.community.platform.images.post_images.domain.repository.Po
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -18,6 +19,7 @@ public class PostImageService implements PostImageUseCase {
 
     /// 게시글에 이미지 저장
     @Override
+    @Transactional
     public PostImage savePostImage(Post post, Image image) {
 
         /// 게시글 이미지 저장하기
@@ -28,7 +30,9 @@ public class PostImageService implements PostImageUseCase {
     }
 
     /// 게시글에 여러개 이미지 저장
+    /// PostImage의 of를 통해 이미지 사용이 확정된다.
     @Override
+    @Transactional
     public List<PostImage> savePostImage(Post post, List<Image> images) {
 
         /// List 형식 극복하기
@@ -43,6 +47,7 @@ public class PostImageService implements PostImageUseCase {
 
     /// 게시글의 여러개 이미지 조회
     @Override
+    @Transactional(readOnly = true)
     public List<PostImage> loadPostImages(Post post) {
         return repository.findByPost(post);
     }

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
@@ -1,5 +1,6 @@
 package bootcamp.kakao.community.platform.images.post_images.application;
 
+import bootcamp.kakao.community.platform.images.image.application.ImageUseCase;
 import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
 import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
 import bootcamp.kakao.community.platform.images.post_images.domain.repository.PostImageRepository;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Service
@@ -16,6 +19,8 @@ import java.util.stream.IntStream;
 public class PostImageService implements PostImageUseCase {
 
     private final PostImageRepository repository;
+    private final ImageUseCase imageService;
+
 
     /// 게시글에 이미지 저장
     @Override
@@ -33,7 +38,10 @@ public class PostImageService implements PostImageUseCase {
     /// PostImage의 of를 통해 이미지 사용이 확정된다.
     @Override
     @Transactional
-    public List<PostImage> savePostImage(Post post, List<Image> images) {
+    public List<PostImage> savePostImage(Post post, List<String> imageUrls) {
+
+        /// 요청한 실제 이미지가 있는지, 불러오기 (영속성 컨테이너)
+        List<Image> images = imageService.getImage(imageUrls);
 
         /// List 형식 극복하기
         List<PostImage> postImages = IntStream.range(0, images.size())
@@ -52,4 +60,49 @@ public class PostImageService implements PostImageUseCase {
         return repository.findByPost(post);
     }
 
+    /// 게시글 이미지 수정하기 (삭제 후, 다시 추가)
+    @Override
+    @Transactional
+    public String updatePostImages(Post post, List<String> imageUrls) {
+
+        /// 기존에 있던 값 조회
+        List<PostImage> oldPostImages = repository.findByPost(post);
+
+        /// 새롭게 요청한 실제 이미지가 있는지, 불러오기 (영속성 컨테이너)
+        List<Image> newImages = imageService.getImage(imageUrls);
+
+        /// 새로 추가한 값에서, 기존에 사용하지 않는 사진은 삭제
+        // 요청 이미지들의 Id 변환
+        Set<Long> newIds = newImages.stream()
+                .map(Image::getId)
+                .collect(Collectors.toSet());
+
+        // 기존에 있던 값에서 사용하지 않는 이미지는 삭제 상태처리
+        List<PostImage> notUseImages = oldPostImages.stream()
+                .filter(oldIm -> !newIds.contains(oldIm.getId()))
+                .toList();
+
+        // Image 삭제 상태로 만들기
+        for (PostImage image : notUseImages) {
+            image.getImage().unConfirm();
+        }
+
+        /// 순서대로 다시 추가하기
+        // 기존 PostImage 전부 삭제하기, S3는 삭제되지않으므로 괜찮을듯.
+        repository.deleteAll(oldPostImages);
+
+        /// List 형식 극복하기
+        List<PostImage> postImages = IntStream.range(0, newImages.size())
+                .mapToObj(i -> PostImage.of(post, newImages.get(i), i))
+                .toList();
+
+        if (!postImages.isEmpty()) {
+            /// 존재한다면 저장 후,첫 이미지 URL 반환
+            repository.saveAll(postImages);
+            return postImages.get(0).getImage().getUrl();
+        }
+
+        /// 없으면
+        return null;
+    }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
@@ -1,4 +1,50 @@
 package bootcamp.kakao.community.platform.images.post_images.application;
 
-public class PostImageService {
+import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
+import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
+import bootcamp.kakao.community.platform.images.post_images.domain.repository.PostImageRepository;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class PostImageService implements PostImageUseCase {
+
+    private final PostImageRepository repository;
+
+    /// 게시글에 이미지 저장
+    @Override
+    public PostImage savePostImage(Post post, Image image) {
+
+        /// 게시글 이미지 저장하기
+        PostImage postImage = PostImage.of(post, image, 0);
+
+        /// 저장하기
+        return repository.save(postImage);
+    }
+
+    /// 게시글에 여러개 이미지 저장
+    @Override
+    public List<PostImage> savePostImage(Post post, List<Image> images) {
+
+        /// List 형식 극복하기
+        List<PostImage> postImages = IntStream.range(0, images.size())
+                .mapToObj(i -> PostImage.of(post, images.get(i), i))
+                .toList();
+
+        /// 저장하기
+        return repository.saveAll(postImages);
+
+    }
+
+    /// 게시글의 여러개 이미지 조회
+    @Override
+    public List<PostImage> loadPostImages(Post post) {
+        return repository.findByPost(post);
+    }
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageUseCase.java
@@ -1,4 +1,19 @@
 package bootcamp.kakao.community.platform.images.post_images.application;
 
+import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
+import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import java.util.List;
+
 public interface PostImageUseCase {
+
+    /// 하나의 이미지를 저장하는 로직
+    PostImage savePostImage(Post post, Image image);
+
+    /// 여러개의 이미지를 저장하는 로직
+    List<PostImage> savePostImage(Post post, List<Image> image);
+
+    /// 게시글에 따른 이미지 조회
+    List<PostImage> loadPostImages(Post post);
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageUseCase.java
@@ -11,9 +11,15 @@ public interface PostImageUseCase {
     PostImage savePostImage(Post post, Image image);
 
     /// 여러개의 이미지를 저장하는 로직
-    List<PostImage> savePostImage(Post post, List<Image> image);
+    List<PostImage> savePostImage(Post post, List<String> image);
 
     /// 게시글에 따른 이미지 조회
     List<PostImage> loadPostImages(Post post);
+
+    /**
+     * 새롭게, 게시글에 따른 이미지 수정
+     * @return  썸네일 추출
+     */
+    String updatePostImages(Post post, List<String> images);
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/dto/PostImageResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/dto/PostImageResponse.java
@@ -1,0 +1,31 @@
+package bootcamp.kakao.community.platform.images.post_images.application.dto;
+
+import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record PostImageResponse(
+        String imageUrl,
+        int order
+) {
+
+    /// 정적 팩토리 메서드
+    public static PostImageResponse from(PostImage postImage) {
+
+        return PostImageResponse.builder()
+                .imageUrl(postImage.getImage().getUrl())
+                .order(postImage.getOrd())
+                .build();
+    }
+
+
+    /// 정적 팩토리 메서드
+    public static List<PostImageResponse> from(List<PostImage> postImages) {
+
+        return postImages.stream()
+                .map(PostImageResponse::from)
+                .toList();
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/domain/entity/PostImage.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/domain/entity/PostImage.java
@@ -40,6 +40,10 @@ public class PostImage extends BaseTimeEntity {
 
     /// 정적 팩토리 메서드
     public static PostImage of(Post post, Image image, int ord) {
+
+        /// 게시글 이미지로 들어가게 되면, 사용 확정
+        image.confirm();
+
         return PostImage.builder()
                 .post(post)
                 .image(image)

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/domain/repository/PostImageRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/domain/repository/PostImageRepository.java
@@ -1,7 +1,11 @@
 package bootcamp.kakao.community.platform.images.post_images.domain.repository;
 
 import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+    List<PostImage> findByPost(Post post);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -1,8 +1,11 @@
 package bootcamp.kakao.community.platform.posts.category.application;
 
+import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 import bootcamp.kakao.community.platform.posts.category.domain.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -10,4 +13,15 @@ public class CategoryService implements CategoryUseCase{
 
     private final CategoryRepository repository;
 
+
+
+
+
+    // =================
+    //  외부 사용 로직
+    // =================
+    @Override
+    public Optional<Category> getCategory(Long id) {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -39,7 +39,7 @@ public class CategoryService implements CategoryUseCase{
     // =================
     @Override
     @Transactional(readOnly = true)
-    public Optional<Category> getCategory(Long id) {
+    public Optional<Category> loadCategory(Long id) {
         return repository.findById(id);
     }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -1,10 +1,13 @@
 package bootcamp.kakao.community.platform.posts.category.application;
 
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 import bootcamp.kakao.community.platform.posts.category.domain.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -13,9 +16,23 @@ public class CategoryService implements CategoryUseCase{
 
     private final CategoryRepository repository;
 
+    /// 카테고리 추가하기
+    @Override
+    @Transactional
+    public void createCategory(CategoryRequest req) {
 
+        Category parent = null;
 
+        /// 부모 값이 존재한다면,
+        if (req.parentId() != null) {
+            parent = repository.findById(req.parentId())
+                    .orElseThrow(NoSuchElementException::new);
+        }
+        Category reqCategory = Category.of(parent, req.name());
 
+        /// 저장
+        repository.save(reqCategory);
+    }
 
     // =================
     //  외부 사용 로직

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -38,7 +38,8 @@ public class CategoryService implements CategoryUseCase{
     //  외부 사용 로직
     // =================
     @Override
+    @Transactional(readOnly = true)
     public Optional<Category> getCategory(Long id) {
-        return Optional.empty();
+        return repository.findById(id);
     }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -3,12 +3,14 @@ package bootcamp.kakao.community.platform.posts.category.application;
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 import bootcamp.kakao.community.platform.posts.category.domain.repository.CategoryRepository;
+import bootcamp.kakao.community.platform.user.application.UserUseCase;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
+import bootcamp.kakao.community.platform.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,12 +18,24 @@ public class CategoryService implements CategoryUseCase{
 
     private final CategoryRepository repository;
 
+    /// 외부 의존성
+    private final UserUseCase userService;
+
     /// 카테고리 추가하기
     @Override
     @Transactional
-    public void createCategory(CategoryRequest req) {
+    public void createCategory(CategoryRequest req, Long userId) {
 
         Category parent = null;
+
+        /// 운영자만 생성 가능
+        /// 운영자라면 삭제하기
+        User user = userService.loadUser(userId);
+
+        /// 운영자가 일때만 가능
+        if (!(user.getRole() == UserRole.ADMIN)) {
+            throw new IllegalStateException("운영자만 카테고리를 생성할 수 있습니다.");
+        }
 
         /// 부모 값이 존재한다면,
         if (req.parentId() != null) {
@@ -32,6 +46,26 @@ public class CategoryService implements CategoryUseCase{
 
         /// 저장
         repository.save(reqCategory);
+    }
+
+    /// 카테고리 삭제하기
+    @Override
+    @Transactional
+    public void deleteCategory(Long id, Long userId) {
+
+        /// 카테고리 조회
+        Category category = loadCategory(id);
+
+        /// 운영자라면 삭제하기
+        User user = userService.loadUser(userId);
+
+        /// 운영자가 일때만 가능
+        if (!(user.getRole() == UserRole.ADMIN)) {
+            throw new IllegalStateException("운영자만 카테고리를 삭제할 수 있습니다.");
+        }
+
+        /// 바로 삭제
+        repository.delete(category);
     }
 
     // =================

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -39,7 +39,8 @@ public class CategoryService implements CategoryUseCase{
     // =================
     @Override
     @Transactional(readOnly = true)
-    public Optional<Category> loadCategory(Long id) {
-        return repository.findById(id);
+    public Category loadCategory(Long id) {
+        return repository.findById(id)
+                .orElseThrow(NoSuchElementException::new);
     }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
@@ -1,4 +1,11 @@
 package bootcamp.kakao.community.platform.posts.category.application;
 
+import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
+
+import java.util.Optional;
+
 public interface CategoryUseCase{
+
+
+    Optional<Category> getCategory(Long id);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
@@ -1,11 +1,15 @@
 package bootcamp.kakao.community.platform.posts.category.application;
 
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 
 import java.util.Optional;
 
 public interface CategoryUseCase{
 
+    /// 카테고리 추가하기
+    void createCategory(CategoryRequest req);
 
+    /// 외부 로직
     Optional<Category> getCategory(Long id);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
@@ -3,12 +3,13 @@ package bootcamp.kakao.community.platform.posts.category.application;
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 
-import java.util.Optional;
-
 public interface CategoryUseCase{
 
-    /// 카테고리 추가하기
-    void createCategory(CategoryRequest req);
+    /// 카테고리 추가하기 (운영자만 가능)
+    void createCategory(CategoryRequest req, Long userId);
+
+    /// 카테고리 삭제하기 (운영자만 가능)
+    void deleteCategory(Long id, Long userId);
 
     /// 외부 로직
     Category loadCategory(Long id);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
@@ -11,5 +11,5 @@ public interface CategoryUseCase{
     void createCategory(CategoryRequest req);
 
     /// 외부 로직
-    Optional<Category> loadCategory(Long id);
+    Category loadCategory(Long id);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
@@ -11,5 +11,5 @@ public interface CategoryUseCase{
     void createCategory(CategoryRequest req);
 
     /// 외부 로직
-    Optional<Category> getCategory(Long id);
+    Optional<Category> loadCategory(Long id);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/dto/CategoryRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/dto/CategoryRequest.java
@@ -1,4 +1,11 @@
 package bootcamp.kakao.community.platform.posts.category.application.dto;
 
-public record CategoryRequest() {
+/**
+ * @param parentId  상위 카테고리
+ * @param name      카테고리 명
+ */
+public record CategoryRequest(
+        Long parentId,
+        String name
+) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/domain/entity/Category.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/domain/entity/Category.java
@@ -38,7 +38,4 @@ public class Category {
                 .name(name)
                 .build();
     }
-
-    /// 비즈니스 로직
-
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/domain/entity/Category.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/domain/entity/Category.java
@@ -21,7 +21,7 @@ public class Category {
     @JoinColumn(name = "parent_id")
     private Category parent;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     /// 빌더 생성자

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/CategoryApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/CategoryApi.java
@@ -1,15 +1,46 @@
 package bootcamp.kakao.community.platform.posts.category.presentation;
 
+import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.platform.posts.category.application.CategoryUseCase;
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
+import bootcamp.kakao.community.platform.posts.category.presentation.swaager.CategoryApiSpec;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/category")
 @RequiredArgsConstructor
-public class CategoryApi {
+public class CategoryApi implements CategoryApiSpec {
 
     private final CategoryUseCase service;
+
+    /// 카테고리 생성
+    @PostMapping()
+    public ApiResponse<Void> create(@RequestBody @Valid CategoryRequest request,
+                                    @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+
+        /// 서비스
+        service.createCategory(request, customUserDetails.getId());
+
+        /// 리턴
+        return ApiResponse.created();
+    }
+
+    /// 카테고리 삭제
+    @DeleteMapping()
+    public ApiResponse<Void> delete(
+            @RequestParam Long categoryId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        /// 서비스
+        service.deleteCategory(categoryId, customUserDetails.getId());
+
+        /// 리턴
+        return ApiResponse.deleted();
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/swaager/CategoryApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/swaager/CategoryApiSpec.java
@@ -1,0 +1,34 @@
+package bootcamp.kakao.community.platform.posts.category.presentation.swaager;
+
+import bootcamp.kakao.community.common.response.ApiResponse;
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "카테고리 API", description = "카테고리 생성/조회/삭제하는 API 입니다.")
+public interface CategoryApiSpec {
+
+    /// 카테고리 작성
+    @Operation(
+            summary = "카테고리 생성 API",
+            description = "카테고리를 생성하는 API 입니다."
+    )
+    ApiResponse<Void> create(@RequestBody @Valid CategoryRequest request,
+                             @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+
+    /// 카테고리 삭제
+    @Operation(
+            summary = "카테고리 삭제 API",
+            description = "카테고리를 삭제하는 API 입니다."
+    )
+    ApiResponse<Void> delete(
+            @RequestParam Long categoryId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
@@ -1,0 +1,131 @@
+package bootcamp.kakao.community.platform.posts.post.application;
+
+import bootcamp.kakao.community.platform.images.image.application.ImageUseCase;
+import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
+import bootcamp.kakao.community.platform.images.post_images.application.PostImageUseCase;
+import bootcamp.kakao.community.platform.posts.category.application.CategoryUseCase;
+import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
+import bootcamp.kakao.community.platform.user.application.UserUseCase;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class PostCommandService implements PostCommandUseCase{
+
+    private final PostRepository repository;
+
+    /// 의존성
+    private final UserUseCase userService;
+    private final CategoryUseCase categoryService;
+
+    /// 이미지
+    private final ImageUseCase imageService;
+    private final PostImageUseCase postImageService;
+
+    /// 게시글 작성, 다중 이미지 고려해서 작성
+    @Override
+    @Transactional
+    public void create(PostRequest req, Long userId) {
+
+        /// 카테고리 예외처리
+        Category category = loadCategory(req.categoryId());
+
+        /// 유저 예외처리
+        User user = loadUser(userId);
+
+        /// 요청한 실제 이미지가 있는지, 불러오기 (영속성 컨테이너)
+        List<Image> image = imageService.getImage(req.imageUrls());
+
+        String thumbnailUrl = null;
+
+        /// 존재한다면
+        if (!image.isEmpty()) {
+            /// 썸네일 추출
+            Image thumbnailImage = image.get(0);
+            thumbnailUrl = thumbnailImage.getUrl();
+        }
+
+        /// 게시글 객체 생성 및 저장 (영속성 컨테이너)
+        var reqPost = Post.of(user, category, req.title(), req.content(), thumbnailUrl);
+        Post post = repository.save(reqPost);
+
+        /// 이미지 저장 (영속성 컨테이너에 저장하기), 생성과 함께 Image의 사용이 확정된다.
+        postImageService.savePostImage(post, image);
+
+    }
+
+
+    /// 게시글 수정
+    /// 더티체킹으로 실행
+    @Override
+    @Transactional
+    public void update(PostUpdateRequest req, Long userId) {
+
+        /// 게시글 상세 조회 (영속성 컨테이너에 스냅샷)
+        Post post = loadPost(req.id());
+
+        /// 유저 예외 처리
+        User user = loadUser(userId);
+
+        /// 동일 유저인지 체크
+        if (!post.getUser().getId().equals(user.getId())){
+            throw new AccessDeniedException("수정할 권한이 없습니다.");
+        }
+
+        /// 게시글 수정
+        post.update(req.title(), req.content());
+
+    }
+
+    /// 게시글 소프트삭제
+    /// 더티체킹으로 실행
+    @Override
+    @Transactional
+    public void delete(Long postId, Long userId) {
+
+        /// 게시글 상세 조회 (영속성 컨테이너에 스냅샷)
+        Post post = loadPost(postId);
+
+        /// 유저 예외 처리 (softDELETE 여부 체크)
+        User user = loadUser(userId);
+
+        /// 동일 유저인지 체크
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedException("삭제할 권한이 없습니다.");
+        }
+
+        /// 게시글 수정
+        post.delete();
+
+    }
+
+    // =================
+    //  내부 로직
+    // =================
+
+    @Transactional(readOnly = true)
+    protected Post loadPost(Long postId) {
+        return repository.findByIdAndDeletedIsFalse(postId)
+                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 게시글이 없습니다."));
+    }
+
+
+    private User loadUser(Long userId) {
+        return userService.loadUser(userId);
+    }
+
+    private Category loadCategory(Long categoryId) {
+        return categoryService.loadCategory(categoryId);
+    }
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandUseCase.java
@@ -1,0 +1,17 @@
+package bootcamp.kakao.community.platform.posts.post.application;
+
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+
+public interface PostCommandUseCase {
+
+    /// 글 작성
+    void create(PostRequest req, Long userId);
+
+    /// 게시글 수정하기
+    void update(PostUpdateRequest req, Long userId);
+
+    /// 게시글 삭제하기
+    void delete(Long postId, Long userId);
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryUseCase.java
@@ -3,15 +3,9 @@ package bootcamp.kakao.community.platform.posts.post.application;
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
-import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 
-public interface PostUseCase {
-
-    /// 글 작성
-    void create(PostRequest req, Long userId);
+public interface PostQueryUseCase {
 
     /// 목록 조회하기 (카테고리 기반)
     SliceResponse<PostListResponse> getPosts(SliceRequest req, Long categoryId);
@@ -21,14 +15,5 @@ public interface PostUseCase {
 
     /// 상세 조회하기
     PostDetailResponse getPost(Long postId, Long userId);
-
-    /// 게시글 수정하기
-    void update(PostUpdateRequest req, Long userId);
-
-    /// 게시글 삭제하기
-    void delete(Long postId, Long userId);
-
-    /// 외부사용
-    Post loadPost(Long postId);
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostService.java
@@ -1,12 +1,152 @@
 package bootcamp.kakao.community.platform.posts.post.application;
 
+import bootcamp.kakao.community.common.response.paging.SliceRequest;
+import bootcamp.kakao.community.common.response.paging.SliceResponse;
+import bootcamp.kakao.community.platform.images.image.application.ImageUseCase;
+import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
+import bootcamp.kakao.community.platform.images.post_images.application.PostImageUseCase;
+import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
+import bootcamp.kakao.community.platform.posts.category.application.CategoryUseCase;
+import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
+import bootcamp.kakao.community.platform.user.application.UserUseCase;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
 public class PostService implements PostUseCase{
 
     private final PostRepository repository;
+
+    /// 의존성
+    private final UserUseCase userService;
+    private final CategoryUseCase categoryService;
+
+    /// 이미지
+    private final ImageUseCase imageService;
+    private final PostImageUseCase postImageService;
+
+    /// 게시글 작성
+    @Override
+    @Transactional
+    public void create(PostRequest req, Long userId) {
+
+        /// 카테고리 예외처리
+        Category category = categoryService.getCategory(req.categoryId())
+                .orElseThrow(NoSuchElementException::new);
+
+        /// 유저 예외처리
+        User user = loadUser(userId);
+
+        /// 게시글 객체 생성 및 저장 (영속성 컨테이너)
+        var reqPost = Post.of(user, category, req.title(), req.content());
+        Post post = repository.save(reqPost);
+
+        /// 해당 이미지 불러오기 (영속성 컨테이너)
+        Image image = imageService.getImage(req.imageUrl());
+
+        /// 이미지 저장 (영속성 컨테이너)
+        PostImage postImage = postImageService.savePostImage(post, image);
+
+        /// 사용중인 이미지로 체크 (더티체킹)
+        postImage.getImage().confirm();
+
+    }
+
+
+    /// 게시글 목록 조회
+    @Override
+    @Transactional(readOnly = true)
+    public SliceResponse<PostListResponse> getPosts(SliceRequest req) {
+        return null;
+    }
+
+    /// 게시글 상세 조회
+    @Override
+    @Transactional(readOnly = true)
+    public PostDetailResponse getPost(Long postId) {
+
+        /// 게시글 상세 조회
+        Post post = loadPost(postId);
+
+        /// 게시글 이미지에서 조회하기
+        List<PostImage> images = postImageService.loadPostImages(post);
+
+        /// 응답
+        return PostDetailResponse.from(post, images);
+
+    }
+
+
+
+    /// 게시글 수정
+    /// 더티체킹으로 실행
+    @Override
+    @Transactional
+    public void update(PostUpdateRequest req, Long userId) {
+
+        /// 게시글 상세 조회 (영속성 컨테이너에 스냅샷)
+        Post post = loadPost(req.id());
+
+        /// 유저 예외 처리
+        User user = loadUser(userId);
+
+        /// 동일 유저인지 체크
+        if (!post.getUser().getId().equals(user.getId())){
+            throw new AccessDeniedException("수정할 권한이 없습니다.");
+        }
+
+        /// 게시글 수정
+        post.update(req.title(), req.content());
+
+    }
+
+    /// 게시글 소프트삭제
+    /// 더티체킹으로 실행
+    @Override
+    @Transactional
+    public void delete(Long postId, Long userId) {
+
+        /// 게시글 상세 조회 (영속성 컨테이너에 스냅샷)
+        Post post = loadPost(postId);
+
+        /// 유저 예외 처리 (softDELETE 여부 체크)
+        User user = loadUser(userId);
+
+        /// 동일 유저인지 체크
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedException("삭제할 권한이 없습니다.");
+        }
+
+        /// 게시글 수정
+        post.delete();
+
+    }
+
+    // =================
+    //  내부 로직
+    // =================
+
+    @Transactional(readOnly = true)
+    protected Post loadPost(Long postId) {
+        return repository.findByIdAndDeletedIsFalse(postId)
+                .orElseThrow(NoSuchElementException::new);
+    }
+
+    private User loadUser(Long userId) {
+        return userService.getUser(userId)
+                .orElseThrow(NoSuchElementException::new);
+    }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostService.java
@@ -95,6 +95,7 @@ public class PostService implements PostUseCase{
 
     /// 인기 게시글 목록 조회
     @Override
+    @Transactional(readOnly = true)
     public SliceResponse<PostListResponse> getFavoritePosts(SliceRequest req) {
         return null;
     }
@@ -186,22 +187,24 @@ public class PostService implements PostUseCase{
     }
 
     // =================
-    //  내부 로직
+    //  외부 사용 로직
     // =================
-
     @Transactional(readOnly = true)
-    protected Post loadPost(Long postId) {
+    public Post loadPost(Long postId) {
         return repository.findByIdAndDeletedIsFalse(postId)
                 .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 게시글이 없습니다."));
     }
 
+
+    // =================
+    //  내부 로직
+    // =================
+
     private User loadUser(Long userId) {
-        return userService.getUser(userId)
-                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 유저가 없습니다."));
+        return userService.loadUser(userId);
     }
 
     private Category loadCategory(Long categoryId) {
-        return categoryService.getCategory(categoryId)
-                .orElseThrow(NoSuchElementException::new);
+        return categoryService.loadCategory(categoryId);
     }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostUseCase.java
@@ -9,14 +9,17 @@ import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRe
 
 public interface PostUseCase {
 
-    /// 글 작성자
+    /// 글 작성
     void create(PostRequest req, Long userId);
 
-    /// 목록 조회하기
-    SliceResponse<PostListResponse> getPosts(SliceRequest req);
+    /// 목록 조회하기 (카테고리 기반)
+    SliceResponse<PostListResponse> getPosts(SliceRequest req, Long categoryId);
+
+    /// 목록 조회하기 (인기 기반)
+    SliceResponse<PostListResponse> getFavoritePosts(SliceRequest req);
 
     /// 상세 조회하기
-    PostDetailResponse getPost(Long postId);
+    PostDetailResponse getPost(Long postId, Long userId);
 
     /// 게시글 수정하기
     void update(PostUpdateRequest req, Long userId);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostUseCase.java
@@ -6,6 +6,7 @@ import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailRe
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 
 public interface PostUseCase {
 
@@ -26,5 +27,8 @@ public interface PostUseCase {
 
     /// 게시글 삭제하기
     void delete(Long postId, Long userId);
+
+    /// 외부사용
+    Post loadPost(Long postId);
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostUseCase.java
@@ -1,4 +1,27 @@
 package bootcamp.kakao.community.platform.posts.post.application;
 
+import bootcamp.kakao.community.common.response.paging.SliceRequest;
+import bootcamp.kakao.community.common.response.paging.SliceResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+
 public interface PostUseCase {
+
+    /// 글 작성자
+    void create(PostRequest req, Long userId);
+
+    /// 목록 조회하기
+    SliceResponse<PostListResponse> getPosts(SliceRequest req);
+
+    /// 상세 조회하기
+    PostDetailResponse getPost(Long postId);
+
+    /// 게시글 수정하기
+    void update(PostUpdateRequest req, Long userId);
+
+    /// 게시글 삭제하기
+    void delete(Long postId, Long userId);
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
@@ -4,61 +4,53 @@ import bootcamp.kakao.community.platform.images.post_images.application.dto.Post
 import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.user.application.dto.UserResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import java.util.*;
 
-/**
- * 게시글 상세조회 DTO
- * @param author            작성자
- * @param category          카테고리
- * @param title             제목
- * @param content           내용
- * @param likeCount         좋아요수
- * @param viewCount         조회수
- * @param commentCount      댓글수
- * @param image             이미지
- * @param liked             좋아요 눌렀는지 여부
- * @param editable          수정/삭제 가능 여부
- * @param createdAt         글 작성 시간
- * @param updatedAt         글 수정 시간
- */
+@Schema(
+        name = "[응답][게시글] 게시글 상세 조회 Response",
+        description = "게시글 상세 조회를 위한 DTO입니다."
+)
 @Builder
 public record PostDetailResponse(
         UserResponse author,
+
+        @Schema(description = "카테고리", example = "Q&A")
         String category,
+
+        @Schema(description = "제목", example = "SpringBoot로 게시판 만들기")
         String title,
+
+        @Schema(description = "내용", example = "SpringBoot를 활용한 게시판 개발 방법을 공유합니다.")
         String content,
+
+        @Schema(description = "좋아요 수", example = "53")
         int likeCount,
+
+        @Schema(description = "조회수", example = "1201")
         int viewCount,
+
+        @Schema(description = "댓글수", example = "37")
         int commentCount,
+
+        @Schema(description = "이미지 목록", example = "[{\"imageUrl\": \"https://sample.com/image1.png\"}]")
         List<PostImageResponse> image,
+
+        @Schema(description = "좋아요 여부", example = "true")
         boolean liked,
+
+        @Schema(description = "수정/삭제 가능 여부", example = "false")
         boolean editable,
+
+        @Schema(description = "글 작성 시각", example = "2023-10-02T14:30:00")
         String createdAt,
+
+        @Schema(description = "글 수정 시각", example = "2023-10-03T09:00:00")
         String updatedAt
 ) {
 
-    /// 정적 팩토리 메서드
-    public static PostDetailResponse from(Post post) {
-
-        /// 정보 조회
-        var stat = post.getPostStat();
-
-        return PostDetailResponse.builder()
-                .author(UserResponse.from(post.getUser()))
-                .category(post.getCategory().getName())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .likeCount(stat.getLikeCount())
-                .viewCount(stat.getViewCount())
-                .commentCount(stat.getCommentCount())
-                .image(null)
-                .createdAt(post.getCreatedDate().toString())
-                .updatedAt(post.getModifiedDate().toString())
-                .build();
-    }
-
-    /// 정적 팩토리 메서드
+    /// (비회원용) 정적 팩토리 메서드
     public static PostDetailResponse from(Post post, List<PostImage> imageList) {
 
         /// 정보 조회
@@ -73,6 +65,30 @@ public record PostDetailResponse(
                 .viewCount(stat.getViewCount())
                 .commentCount(stat.getCommentCount())
                 .image(PostImageResponse.from(imageList))
+                .liked(false)
+                .editable(false)
+                .createdAt(post.getCreatedDate().toString())
+                .updatedAt(post.getModifiedDate().toString())
+                .build();
+    }
+
+    /// (회원용) 정적 팩토리 메서드
+    public static PostDetailResponse from(Post post, List<PostImage> imageList, boolean liked, boolean editable) {
+
+        /// 정보 조회
+        var stat = post.getPostStat();
+
+        return PostDetailResponse.builder()
+                .author(UserResponse.from(post.getUser()))
+                .category(post.getCategory().getName())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .likeCount(stat.getLikeCount())
+                .viewCount(stat.getViewCount())
+                .commentCount(stat.getCommentCount())
+                .image(PostImageResponse.from(imageList))
+                .liked(liked)
+                .editable(editable)
                 .createdAt(post.getCreatedDate().toString())
                 .updatedAt(post.getModifiedDate().toString())
                 .build();

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
@@ -1,0 +1,66 @@
+package bootcamp.kakao.community.platform.posts.post.application.dto;
+
+import bootcamp.kakao.community.platform.images.post_images.application.dto.PostImageResponse;
+import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import bootcamp.kakao.community.platform.user.application.dto.UserResponse;
+import lombok.Builder;
+import java.util.*;
+
+@Builder
+public record PostDetailResponse(
+        UserResponse user,
+        String category,
+        String title,
+        String content,
+        int likeCount,
+        int viewCount,
+        int commentCount,
+        List<PostImageResponse> image,
+        String createdAt,
+        String updatedAt
+) {
+
+    /// 정적 팩토리 메서드
+    public static PostDetailResponse from(Post post) {
+
+        /// 정보 조회
+        var stat = post.getPostStat();
+
+        return PostDetailResponse.builder()
+                .user(UserResponse.from(post.getUser()))
+                .category(post.getCategory().getName())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .likeCount(stat.getLikeCount())
+                .viewCount(stat.getViewCount())
+                .commentCount(stat.getCommentCount())
+                .image(null)
+                .createdAt(post.getCreatedDate().toString())
+                .updatedAt(post.getModifiedDate().toString())
+                .build();
+    }
+
+    /// 정적 팩토리 메서드
+    public static PostDetailResponse from(Post post, List<PostImage> imageList) {
+
+        /// 정보 조회
+        var stat = post.getPostStat();
+
+        return PostDetailResponse.builder()
+                .user(UserResponse.from(post.getUser()))
+                .category(post.getCategory().getName())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .likeCount(stat.getLikeCount())
+                .viewCount(stat.getViewCount())
+                .commentCount(stat.getCommentCount())
+                .image(PostImageResponse.from(imageList))
+                .createdAt(post.getCreatedDate().toString())
+                .updatedAt(post.getModifiedDate().toString())
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
@@ -34,7 +34,7 @@ public record PostDetailResponse(
         @Schema(description = "댓글수", example = "37")
         int commentCount,
 
-        @Schema(description = "이미지 목록", example = "[{\"imageUrl\": \"https://sample.com/image1.png\"}]")
+        @Schema(description = "이미지 목록", example = "[{\"thumbnailUrl\": \"https://sample.com/image1.png\"}]")
         List<PostImageResponse> image,
 
         @Schema(description = "좋아요 여부", example = "true")

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
@@ -7,9 +7,24 @@ import bootcamp.kakao.community.platform.user.application.dto.UserResponse;
 import lombok.Builder;
 import java.util.*;
 
+/**
+ * 게시글 상세조회 DTO
+ * @param author            작성자
+ * @param category          카테고리
+ * @param title             제목
+ * @param content           내용
+ * @param likeCount         좋아요수
+ * @param viewCount         조회수
+ * @param commentCount      댓글수
+ * @param image             이미지
+ * @param liked             좋아요 눌렀는지 여부
+ * @param editable          수정/삭제 가능 여부
+ * @param createdAt         글 작성 시간
+ * @param updatedAt         글 수정 시간
+ */
 @Builder
 public record PostDetailResponse(
-        UserResponse user,
+        UserResponse author,
         String category,
         String title,
         String content,
@@ -17,6 +32,8 @@ public record PostDetailResponse(
         int viewCount,
         int commentCount,
         List<PostImageResponse> image,
+        boolean liked,
+        boolean editable,
         String createdAt,
         String updatedAt
 ) {
@@ -28,7 +45,7 @@ public record PostDetailResponse(
         var stat = post.getPostStat();
 
         return PostDetailResponse.builder()
-                .user(UserResponse.from(post.getUser()))
+                .author(UserResponse.from(post.getUser()))
                 .category(post.getCategory().getName())
                 .title(post.getTitle())
                 .content(post.getContent())
@@ -48,7 +65,7 @@ public record PostDetailResponse(
         var stat = post.getPostStat();
 
         return PostDetailResponse.builder()
-                .user(UserResponse.from(post.getUser()))
+                .author(UserResponse.from(post.getUser()))
                 .category(post.getCategory().getName())
                 .title(post.getTitle())
                 .content(post.getContent())

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
@@ -16,6 +16,9 @@ import java.util.*;
 public record PostDetailResponse(
         UserResponse author,
 
+        @Schema(description = "게시글 ID", example = "1")
+        Long id,
+
         @Schema(description = "카테고리", example = "Q&A")
         String category,
 
@@ -57,6 +60,7 @@ public record PostDetailResponse(
         var stat = post.getPostStat();
 
         return PostDetailResponse.builder()
+                .id(post.getId())
                 .author(UserResponse.from(post.getUser()))
                 .category(post.getCategory().getName())
                 .title(post.getTitle())

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
@@ -1,0 +1,15 @@
+package bootcamp.kakao.community.platform.posts.post.application.dto;
+
+import bootcamp.kakao.community.platform.user.application.dto.UserResponse;
+
+public record PostListResponse(
+        UserResponse user,
+        String category,
+        String title,
+        String content,
+        int viewCount,
+        int commentCount,
+        String createdAt,
+        String updatedAt
+) {
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
@@ -1,15 +1,55 @@
 package bootcamp.kakao.community.platform.posts.post.application.dto;
 
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.user.application.dto.UserResponse;
+import lombok.Builder;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "[응답][게시글] 게시글 목록 조회 Response",
+        description = "게시글 목록 조회를 위한 DTO입니다."
+)
+@Builder
 public record PostListResponse(
         UserResponse user,
+
+        @Schema(description = "카테고리", example = "자유게시판")
         String category,
+
+        @Schema(description = "썸네일 URL", example = "https://example.com/image.png")
+        String imageUrl,
+
+        @Schema(description = "제목", example = "오늘의 게시글")
         String title,
+
+        @Schema(description = "내용", example = "오늘은 날씨가 좋네요.")
         String content,
+
+        @Schema(description = "조회수", example = "102")
         int viewCount,
+
+        @Schema(description = "댓글수", example = "18")
         int commentCount,
-        String createdAt,
-        String updatedAt
+
+        @Schema(description = "작성일시", example = "2023-10-02T14:30:00")
+        String createdAt
+
 ) {
+    /// (회원용) 정적 팩토리 메서드
+    public static PostListResponse from(Post post) {
+
+        /// 게시글 정보 조회
+        var stat = post.getPostStat();
+
+        return PostListResponse.builder()
+                .user(UserResponse.from(post.getUser()))
+                .category(post.getCategory().getName())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .viewCount(stat.getViewCount())
+                .commentCount(stat.getCommentCount())
+                .createdAt(post.getCreatedDate().toString())
+                .build();
+    }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
@@ -18,6 +18,9 @@ import java.util.List;
 public record PostListResponse(
         UserResponse user,
 
+        @Schema(description = "게시글 ID", example = "1")
+        Long id,
+
         @Schema(description = "카테고리", example = "자유게시판")
         String category,
 
@@ -47,6 +50,7 @@ public record PostListResponse(
         var stat = post.getPostStat();
 
         return PostListResponse.builder()
+                .id(post.getId())
                 .user(UserResponse.from(post.getUser()))
                 .category(post.getCategory().getName())
                 .thumbnailUrl(post.getThumbnailUrl())

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
@@ -5,6 +5,10 @@ import bootcamp.kakao.community.platform.user.application.dto.UserResponse;
 import lombok.Builder;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
 
 @Schema(
         name = "[응답][게시글] 게시글 목록 조회 Response",
@@ -18,7 +22,7 @@ public record PostListResponse(
         String category,
 
         @Schema(description = "썸네일 URL", example = "https://example.com/image.png")
-        String imageUrl,
+        String thumbnailUrl,
 
         @Schema(description = "제목", example = "오늘의 게시글")
         String title,
@@ -36,7 +40,7 @@ public record PostListResponse(
         String createdAt
 
 ) {
-    /// (회원용) 정적 팩토리 메서드
+    /// 정적 팩토리 메서드
     public static PostListResponse from(Post post) {
 
         /// 게시글 정보 조회
@@ -45,11 +49,24 @@ public record PostListResponse(
         return PostListResponse.builder()
                 .user(UserResponse.from(post.getUser()))
                 .category(post.getCategory().getName())
+                .thumbnailUrl(post.getThumbnailUrl())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .viewCount(stat.getViewCount())
                 .commentCount(stat.getCommentCount())
                 .createdAt(post.getCreatedDate().toString())
                 .build();
+    }
+
+    /// 정적 팩토리 메서드
+    public static Slice<PostListResponse> from(Slice<Post> posts) {
+
+        /// 게시글 정보 조회
+        List<PostListResponse> responses = posts.stream()
+                .map(PostListResponse::from)
+                .toList();
+
+        /// Slice 리턴
+        return new SliceImpl<>(responses, posts.getPageable(), posts.hasNext());
     }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
@@ -14,7 +14,6 @@ import java.util.List;
  */
 public record PostRequest(
 
-        @NotNull
         @NotNull(message = "카테고리없이 게시글을 작성할 수 없습니다.")
         Long categoryId,
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
@@ -1,0 +1,9 @@
+package bootcamp.kakao.community.platform.posts.post.application.dto;
+
+public record PostRequest(
+        Long categoryId,
+        String title,
+        String content,
+        String imageUrl
+) {
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
@@ -1,9 +1,18 @@
 package bootcamp.kakao.community.platform.posts.post.application.dto;
 
+import java.util.List;
+
+/**
+ * 이미지 생성 요청 DTO
+ * @param categoryId    카테고리 ID
+ * @param title         제목
+ * @param content       내용
+ * @param imageUrls     이미지 URLs
+ */
 public record PostRequest(
         Long categoryId,
         String title,
         String content,
-        String imageUrl
+        List<String> imageUrls
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
@@ -1,5 +1,8 @@
 package bootcamp.kakao.community.platform.posts.post.application.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import java.util.List;
 
 /**
@@ -10,9 +13,18 @@ import java.util.List;
  * @param imageUrls     이미지 URLs
  */
 public record PostRequest(
+
+        @NotNull
+        @NotNull(message = "카테고리없이 게시글을 작성할 수 없습니다.")
         Long categoryId,
+
+        @Size(max = 26, message = "제목의 길이가 26자를 넘습니다.")
+        @NotNull(message = "제목없이 게시글을 작성할 수 없습니다.")
         String title,
+
+        @NotNull(message = "내용없이 게시글을 작성할 수 없습니다.")
         String content,
+
         List<String> imageUrls
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
@@ -1,0 +1,11 @@
+package bootcamp.kakao.community.platform.posts.post.application.dto;
+
+public record PostUpdateRequest(
+        Long id,
+        Long categoryId,
+        String title,
+        String content,
+        String imageUrl
+
+) {
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
@@ -1,11 +1,12 @@
 package bootcamp.kakao.community.platform.posts.post.application.dto;
 
+import java.util.List;
+
 public record PostUpdateRequest(
         Long id,
         Long categoryId,
         String title,
         String content,
-        String imageUrl
-
+        List<String> imageUrls
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/Post.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/Post.java
@@ -28,6 +28,9 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @Column(length = 1000)
+    private String thumbnailUrl;
+
     @Column(nullable = false)
     private String title;
 
@@ -43,7 +46,7 @@ public class Post extends BaseTimeEntity {
 
     /// 빌더 생성자
     @Builder
-    protected Post(User user, Category category, String title, String content) {
+    protected Post(User user, Category category, String title, String content, String thumbnailUrl) {
 
         /// 예외 처리
         if (user == null) {
@@ -63,17 +66,19 @@ public class Post extends BaseTimeEntity {
         this.category = category;
         this.title = title;
         this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
         this.deleted = false;
         this.postStat = new PostStat();
     }
 
     /// 정적 팩토리 메서드
-    public static Post of(User user, Category category, String title, String content) {
+    public static Post of(User user, Category category, String title, String content, String thumbnailUrl) {
         return Post.builder()
                 .user(user)
                 .category(category)
                 .title(title)
                 .content(content)
+                .thumbnailUrl(thumbnailUrl)
                 .build();
     }
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/Post.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/Post.java
@@ -88,7 +88,7 @@ public class Post extends BaseTimeEntity {
     }
 
     /// 수정
-    public void update(String title, String content) {
+    public void update(String title, String content, String thumbnailUrl) {
 
         if (title != null) {
             /// 제목을 수정할 내용이 존재한다면,
@@ -97,6 +97,11 @@ public class Post extends BaseTimeEntity {
         if (content != null) {
             /// 내용을 수정할 내용이 존재한다면,
             this.content = content;
+        }
+
+        if (thumbnailUrl != null) {
+            /// 바꿀 썸네일이 존재한다면,
+            this.thumbnailUrl = thumbnailUrl;
         }
     }
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/Post.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/Post.java
@@ -44,6 +44,21 @@ public class Post extends BaseTimeEntity {
     /// 빌더 생성자
     @Builder
     protected Post(User user, Category category, String title, String content) {
+
+        /// 예외 처리
+        if (user == null) {
+            throw new IllegalArgumentException("작성자(user)는 필수입니다.");
+        }
+        if (category == null) {
+            throw new IllegalArgumentException("카테고리(category)는 필수입니다.");
+        }
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("제목(title)은 비어있을 수 없습니다.");
+        }
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("내용(content)은 비어있을 수 없습니다.");
+        }
+
         this.user = user;
         this.category = category;
         this.title = title;
@@ -60,6 +75,24 @@ public class Post extends BaseTimeEntity {
                 .title(title)
                 .content(content)
                 .build();
+    }
+
+    /// 비즈니스 로직
+    public void delete() {
+        this.deleted = true;
+    }
+
+    /// 수정
+    public void update(String title, String content) {
+
+        if (title != null) {
+            /// 제목을 수정할 내용이 존재한다면,
+            this.title = title;
+        }
+        if (content != null) {
+            /// 내용을 수정할 내용이 존재한다면,
+            this.content = content;
+        }
     }
 
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepository.java
@@ -4,9 +4,8 @@ import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
+    /// 삭제되지않은 게시글 조회
     Optional<Post> findByIdAndDeletedIsFalse(Long id);
-
-
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepository.java
@@ -2,6 +2,11 @@ package bootcamp.kakao.community.platform.posts.post.domain.repository;
 
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findByIdAndDeletedIsFalse(Long id);
+
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepositoryCustom.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepositoryCustom.java
@@ -1,0 +1,16 @@
+package bootcamp.kakao.community.platform.posts.post.domain.repository;
+
+import bootcamp.kakao.community.common.response.paging.SliceRequest;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import org.springframework.data.domain.Slice;
+
+public interface PostRepositoryCustom {
+
+    /**
+     * NoOffset을 기반으로 조회한다.
+     * @param sliceRequest  슬라이싱 요청
+     * @param category      카테고리
+     */
+    Slice<Post> findPostsByCursor(SliceRequest sliceRequest, String category, boolean deleted);
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,85 @@
+package bootcamp.kakao.community.platform.posts.post.domain.repository;
+
+import bootcamp.kakao.community.common.response.paging.SliceRequest;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static bootcamp.kakao.community.platform.posts.post.domain.entity.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostRepositoryCustomImpl implements PostRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    /// NoOffset 으로 구현
+    @Override
+    public Slice<Post> findPostsByCursor(SliceRequest sliceRequest, String category, boolean deleted) {
+
+        /// 해당하는 만큼 조회
+        List<Post> fetch = queryFactory
+                .selectFrom(post)
+                .where(
+                        ltLastId(sliceRequest.lastId()),
+                        eqCategory(category),
+                        eqDeleted(deleted)
+                )
+                .orderBy(post.id.desc())
+                .limit(sliceRequest.offSet() + 1) // hasNext 확인용 +1
+                .fetch();
+
+
+        /// SliceImpl 제작
+        boolean hasNext = false;
+        if (fetch.size() > sliceRequest.offSet()) {
+
+            /// 조회했던 값은 삭제
+            fetch.remove(sliceRequest.offSet());
+            hasNext = true;
+        }
+
+        /// Pageable 제작
+        Pageable pageable = PageRequest.of(0, sliceRequest.offSet());
+
+        /// 응답 생성
+        return new SliceImpl<>(fetch, pageable, hasNext);
+
+    }
+
+    /// id < 첫 번째 조회에서는 파라미터를 사용하지 않기 위한 동적 쿼리
+    private BooleanExpression ltLastId(Long lastId) {
+
+        if (lastId == null) {
+            /// BooleanExpression 자리에 null이 반환되면 조건문에서 자동을 제외된다.
+            return null;
+        }
+        return post.id.lt(lastId);
+    }
+
+    /// 카테고리
+    private BooleanExpression eqCategory(String category) {
+
+        if (category == null) {
+            /// BooleanExpression 자리에 null이 반환되면 조건문에서 자동을 제외된다.
+            return null;
+        }
+        return post.category.name.eq(category);
+    }
+
+    private BooleanExpression eqDeleted(boolean deleted) {
+
+        return post.deleted.eq(deleted);
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/repository/PostRepositoryCustomImpl.java
@@ -2,7 +2,7 @@ package bootcamp.kakao.community.platform.posts.post.domain.repository;
 
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -58,28 +58,34 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
     }
 
     /// id < 첫 번째 조회에서는 파라미터를 사용하지 않기 위한 동적 쿼리
-    private BooleanExpression ltLastId(Long lastId) {
+    private BooleanBuilder ltLastId(Long lastId) {
+
+        BooleanBuilder builder = new BooleanBuilder();
 
         if (lastId == null) {
             /// BooleanExpression 자리에 null이 반환되면 조건문에서 자동을 제외된다.
             return null;
         }
-        return post.id.lt(lastId);
+        return builder.and(post.id.lt(lastId));
     }
 
     /// 카테고리
-    private BooleanExpression eqCategory(String category) {
+    private BooleanBuilder eqCategory(String category) {
+
+        BooleanBuilder builder = new BooleanBuilder();
 
         if (category == null) {
             /// BooleanExpression 자리에 null이 반환되면 조건문에서 자동을 제외된다.
             return null;
         }
-        return post.category.name.eq(category);
+        return builder.and(post.category.name.eq(category));
     }
 
-    private BooleanExpression eqDeleted(boolean deleted) {
+    private BooleanBuilder eqDeleted(boolean deleted) {
 
-        return post.deleted.eq(deleted);
+        BooleanBuilder builder = new BooleanBuilder();
+
+        return builder.and(post.deleted.eq(deleted));
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
@@ -8,6 +8,7 @@ import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailRe
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.platform.posts.post.presentation.swagger.PostApiSpec;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/v1/posts")
 @RequiredArgsConstructor
-public class PostApi {
+public class PostApi implements PostApiSpec {
 
     private final PostUseCase service;
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
@@ -3,7 +3,8 @@ package bootcamp.kakao.community.platform.posts.post.presentation;
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
-import bootcamp.kakao.community.platform.posts.post.application.PostUseCase;
+import bootcamp.kakao.community.platform.posts.post.application.PostCommandUseCase;
+import bootcamp.kakao.community.platform.posts.post.application.PostQueryUseCase;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
@@ -20,7 +21,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class PostApi implements PostApiSpec {
 
-    private final PostUseCase service;
+    private final PostCommandUseCase commandService;
+    private final PostQueryUseCase queryService;
 
     /// 글 작성
     @PostMapping
@@ -29,7 +31,7 @@ public class PostApi implements PostApiSpec {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         /// 서비스 작성
-        service.create(request, customUserDetails.getId());
+        commandService.create(request, customUserDetails.getId());
 
         /// 리턴
         return ApiResponse.created();
@@ -46,7 +48,7 @@ public class PostApi implements PostApiSpec {
         Long userId = customUserDetails != null ? customUserDetails.getId() : null;
 
         /// 서비스 읽기
-        PostDetailResponse response = service.getPost(postId, userId);
+        PostDetailResponse response = queryService.getPost(postId, userId);
 
         /// 리턴
         return ApiResponse.ok(response);
@@ -60,7 +62,7 @@ public class PostApi implements PostApiSpec {
             @RequestParam Long categoryId) {
 
         /// 서비스 읽기
-        SliceResponse<PostListResponse> response = service.getPosts(sliceRequest, categoryId);
+        SliceResponse<PostListResponse> response = queryService.getPosts(sliceRequest, categoryId);
 
         /// 리턴
         return ApiResponse.ok(response);
@@ -74,7 +76,7 @@ public class PostApi implements PostApiSpec {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         /// 서비스 수정
-        service.update(request, customUserDetails.getId());
+        commandService.update(request, customUserDetails.getId());
 
         /// 리턴
         return ApiResponse.updated();
@@ -87,7 +89,7 @@ public class PostApi implements PostApiSpec {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         /// 서비스 삭제
-        service.delete(postId, customUserDetails.getId());
+        commandService.delete(postId, customUserDetails.getId());
 
         /// 리턴
         return ApiResponse.deleted();

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
@@ -1,9 +1,18 @@
 package bootcamp.kakao.community.platform.posts.post.presentation;
 
+import bootcamp.kakao.community.common.response.ApiResponse;
+import bootcamp.kakao.community.common.response.paging.SliceRequest;
+import bootcamp.kakao.community.common.response.paging.SliceResponse;
 import bootcamp.kakao.community.platform.posts.post.application.PostUseCase;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/posts")
@@ -12,4 +21,66 @@ public class PostApi {
 
     private final PostUseCase service;
 
+    /// 글 작성
+    @PostMapping
+    public ApiResponse<Void> createPost(
+            @RequestBody @Valid PostRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        /// 서비스 작성
+        service.create(request, customUserDetails.getId());
+
+        /// 리턴
+        return ApiResponse.created();
+    }
+
+    /// 글 상세 조회
+    @GetMapping("/{postId}")
+    public ApiResponse<PostDetailResponse> readPost(@PathVariable Long postId) {
+
+        /// 서비스 읽기
+        PostDetailResponse response = service.getPost(postId);
+
+        /// 리턴
+        return ApiResponse.ok(response);
+    }
+
+
+    /// 글 목록 조회
+    @GetMapping()
+    public ApiResponse<SliceResponse<PostListResponse>> readPosts(SliceRequest sliceRequest) {
+
+        /// 서비스 읽기
+        SliceResponse<PostListResponse> response = service.getPosts(sliceRequest);
+
+        /// 리턴
+        return ApiResponse.ok(response);
+    }
+
+
+    /// 글 수정
+    @PatchMapping("/{postId}")
+    public ApiResponse<Void> updatePost(
+            @RequestBody @Valid PostUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        /// 서비스 수정
+        service.update(request, customUserDetails.getId());
+
+        /// 리턴
+        return ApiResponse.updated();
+    }
+
+    /// 글 삭제 (소프트 삭제)
+    @PutMapping("/{postId}")
+    public ApiResponse<Void> delete(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        /// 서비스 삭제
+        service.delete(postId, customUserDetails.getId());
+
+        /// 리턴
+        return ApiResponse.deleted();
+    }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
@@ -37,10 +37,16 @@ public class PostApi implements PostApiSpec {
 
     /// 글 상세 조회
     @GetMapping("/{postId}")
-    public ApiResponse<PostDetailResponse> readPost(@PathVariable Long postId) {
+    public ApiResponse<PostDetailResponse> readPost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+
+        /// 유저가 없다면 null 저장
+        Long userId = customUserDetails != null ? customUserDetails.getId() : null;
 
         /// 서비스 읽기
-        PostDetailResponse response = service.getPost(postId);
+        PostDetailResponse response = service.getPost(postId, userId);
 
         /// 리턴
         return ApiResponse.ok(response);
@@ -49,10 +55,12 @@ public class PostApi implements PostApiSpec {
 
     /// 글 목록 조회
     @GetMapping()
-    public ApiResponse<SliceResponse<PostListResponse>> readPosts(SliceRequest sliceRequest) {
+    public ApiResponse<SliceResponse<PostListResponse>> readPosts(
+            SliceRequest sliceRequest,
+            @RequestParam Long categoryId) {
 
         /// 서비스 읽기
-        SliceResponse<PostListResponse> response = service.getPosts(sliceRequest);
+        SliceResponse<PostListResponse> response = service.getPosts(sliceRequest, categoryId);
 
         /// 리턴
         return ApiResponse.ok(response);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "게시글 API", description = "게시글 관련 API 입니다.")
 public interface PostApiSpec {
@@ -33,7 +34,8 @@ public interface PostApiSpec {
             summary = "게시글 상세 조회 API",
             description = "게시글을 조회하는 API 입니다."
     )
-    ApiResponse<PostDetailResponse> readPost(@PathVariable Long postId);
+    ApiResponse<PostDetailResponse> readPost(@PathVariable Long postId,
+                                             @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
 
     /// 글 목록 조회
@@ -41,7 +43,9 @@ public interface PostApiSpec {
             summary = "게시글 목록 조회 API",
             description = "게시글 목록을 조회하는 API 입니다."
     )
-    ApiResponse<SliceResponse<PostListResponse>> readPosts(SliceRequest sliceRequest);
+    ApiResponse<SliceResponse<PostListResponse>> readPosts(
+            SliceRequest sliceRequest,
+            @RequestParam Long categoryId);
 
 
     /// 글 수정

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
@@ -1,0 +1,66 @@
+package bootcamp.kakao.community.platform.posts.post.presentation.swagger;
+
+import bootcamp.kakao.community.common.response.ApiResponse;
+import bootcamp.kakao.community.common.response.paging.SliceRequest;
+import bootcamp.kakao.community.common.response.paging.SliceResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "게시글 API", description = "게시글 관련 API 입니다.")
+public interface PostApiSpec {
+
+    /// 글 작성
+    @Operation(
+            summary = "게시글 작성 API",
+            description = "게시글을 작성하는 API 입니다."
+    )
+    ApiResponse<Void> createPost(
+            @RequestBody @Valid PostRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+
+    /// 글 상세 조회
+    @Operation(
+            summary = "게시글 상세 조회 API",
+            description = "게시글을 조회하는 API 입니다."
+    )
+    ApiResponse<PostDetailResponse> readPost(@PathVariable Long postId);
+
+
+    /// 글 목록 조회
+    @Operation(
+            summary = "게시글 목록 조회 API",
+            description = "게시글 목록을 조회하는 API 입니다."
+    )
+    ApiResponse<SliceResponse<PostListResponse>> readPosts(SliceRequest sliceRequest);
+
+
+    /// 글 수정
+    @Operation(
+            summary = "게시글 수정 API",
+            description = "게시글을 수정하는 API 입니다."
+    )
+    ApiResponse<Void> updatePost(
+            @RequestBody @Valid PostUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+
+    /// 글 삭제 (소프트 삭제)
+    @Operation(
+            summary = "게시글 삭제 API",
+            description = "게시글을 삭제하는 API 입니다."
+    )
+    ApiResponse<Void> delete(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeService.java
@@ -1,13 +1,121 @@
 package bootcamp.kakao.community.platform.posts.post_likes.application;
 
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
+import bootcamp.kakao.community.platform.posts.post_likes.application.dto.PostLikeRequest;
+import bootcamp.kakao.community.platform.posts.post_likes.domain.entity.PostLike;
 import bootcamp.kakao.community.platform.posts.post_likes.domain.repository.PostLikeRepository;
+import bootcamp.kakao.community.platform.user.application.UserUseCase;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class PostLikeService implements PostLikeUseCase{
+public class PostLikeService implements PostLikeUseCase {
 
+    /// 의존성
     private final PostLikeRepository repository;
+
+    /// 외부 의존성
+    private final PostRepository postRepository;
+    private final UserUseCase userService;
+
+    @Override
+    @Transactional
+    public void like(PostLikeRequest request, Long userId) {
+
+        /// 존재하는 유저인 지 예외처리
+        User user = loadUser(userId);
+
+        /// 존재하는 게시글인 지 예외처리
+        Post post = loadPost(request.postId());
+
+        /// 객체 생성 및 저장
+        PostLike reqLike = PostLike.of(user, post);
+        repository.save(reqLike);
+
+    }
+
+    @Override
+    @Transactional
+    public void unlike(Long postId, Long userId) {
+
+        /// 존재하는 유저인 지 예외처리
+        User user = loadUser(userId);
+
+        /// 헤당 유저가 좋아요를 눌렀었는지 체크
+        Post post = loadPost(postId);
+
+        Optional<PostLike> optionalPostLike = repository.findByUserAndPost(user, post);
+        if (optionalPostLike.isEmpty()) {
+            /// 없다면 예외처리
+            throw new IllegalStateException("좋아요를 누르지 않았기에 취소가 불가능합니다.");
+        }
+
+        /// 삭제 처리 (바로 삭제)
+        repository.delete(optionalPostLike.get());
+    }
+
+    /**
+     * 예외처리가 된 값들로 처리하는 서비스 로직
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isLiked(Long postId, Long userId) {
+
+        Optional<PostLike> optionalPostLike = repository.findByUser_IdAndPost_Id(userId, postId);
+
+        if (optionalPostLike.isEmpty()) {
+            /// 없다면 fasle
+            return false;
+        } else {
+            /// 있다면 true
+            return true;
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Post> loadLikedPosts(Long userId) {
+
+        /// UserId 값으로 조회 (인덱스 처리)
+        List<PostLike> likes = repository.findByUser_Id(userId);
+
+        /// N+1 문제 발생
+        /// TODO! fetch Join 으로 고치기
+        return likes.stream()
+                .map(PostLike::getPost)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> loadLikedUsers(Long postId) {
+
+        /// PostId 값으로 조회 (인덱스 처리)
+        List<PostLike> likes = repository.findByPost_Id(postId);
+
+        /// N+1 문제 발생
+        /// TODO! fetch Join 으로 고치기
+        return likes.stream()
+                .map(PostLike::getUser)
+                .toList();
+    }
+
+
+    private Post loadPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 게시글이 없습니다."));
+    }
+
+    private User loadUser(Long userId) {
+        return userService.loadUser(userId);
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeUseCase.java
@@ -1,4 +1,30 @@
 package bootcamp.kakao.community.platform.posts.post_likes.application;
 
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import bootcamp.kakao.community.platform.posts.post_likes.application.dto.PostLikeRequest;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
+
+import java.util.List;
+
 public interface PostLikeUseCase {
+
+    /// 좋아요 누르기
+    void like(PostLikeRequest request, Long userId);
+
+    /// 좋아요 취소하기
+    void unlike(Long postId, Long userId);
+
+    // =================
+    //  외부 사용 로직
+    // =================
+
+    /// 나의 좋아요 여부 파악하기
+    boolean isLiked(Long postId, Long userId);
+
+    /// 나의 좋아요 목록 조회하기
+    List<Post> loadLikedPosts(Long userId);
+
+    /// 좋아요한 유저들 목록 조회하기
+    List<User> loadLikedUsers(Long postId);
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/dto/PostLikeRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/dto/PostLikeRequest.java
@@ -1,4 +1,13 @@
 package bootcamp.kakao.community.platform.posts.post_likes.application.dto;
 
-public record PostLikeRequest() {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "[요청][좋아요] 게시글 좋아요 Reqeust",
+        description = "좋아요 생성을 위한 DTO입니다."
+)
+public record PostLikeRequest(
+        @Schema(description = "게시글 ID", example = "1")
+        Long postId
+) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/dto/PostLikeResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/dto/PostLikeResponse.java
@@ -1,4 +1,0 @@
-package bootcamp.kakao.community.platform.posts.post_likes.application.dto;
-
-public record PostLikeResponse() {
-}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/domain/repository/PostLikeRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/domain/repository/PostLikeRepository.java
@@ -1,8 +1,20 @@
 package bootcamp.kakao.community.platform.posts.post_likes.domain.repository;
 
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.posts.post_likes.domain.entity.PostLike;
 import bootcamp.kakao.community.platform.posts.post_likes.domain.entity.PostLikeId;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.*;
+
 public interface PostLikeRepository extends JpaRepository<PostLike, PostLikeId> {
+
+    Optional<PostLike> findByUserAndPost(User user, Post post);
+
+    Optional<PostLike> findByUser_IdAndPost_Id(Long userId, Long postId);
+
+    List<PostLike> findByUser_Id(Long userId);
+
+    List<PostLike> findByPost_Id(Long postId);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/presentation/PostLikeApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/presentation/PostLikeApi.java
@@ -1,15 +1,46 @@
 package bootcamp.kakao.community.platform.posts.post_likes.presentation;
 
+import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.platform.posts.post_likes.application.PostLikeUseCase;
+import bootcamp.kakao.community.platform.posts.post_likes.application.dto.PostLikeRequest;
+import bootcamp.kakao.community.platform.posts.post_likes.presentation.swagger.PostLikeApiSpec;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/posts/likes")
 @RequiredArgsConstructor
-public class PostLikeApi {
+public class PostLikeApi implements PostLikeApiSpec {
 
     private final PostLikeUseCase service;
+
+    /// 좋아요 생성
+    @PostMapping
+    public ApiResponse<Void> like(
+            @RequestBody @Valid PostLikeRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        /// 서비스
+        service.like(request, customUserDetails.getId());
+
+        /// 리턴
+        return ApiResponse.created();
+    }
+
+    /// 좋아요 취소
+    @DeleteMapping
+    public ApiResponse<Void> unlike(
+            @RequestParam Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        /// 서비스
+        service.unlike(postId, customUserDetails.getId());
+
+        /// 리턴
+        return ApiResponse.deleted();
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/presentation/swagger/PostLikeApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/presentation/swagger/PostLikeApiSpec.java
@@ -1,0 +1,37 @@
+package bootcamp.kakao.community.platform.posts.post_likes.presentation.swagger;
+
+import bootcamp.kakao.community.common.response.ApiResponse;
+import bootcamp.kakao.community.platform.posts.post_likes.application.dto.PostLikeRequest;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "게시글 좋아요 API", description = "게시글 좋아요 생성/취소하는 API 입니다.")
+public interface PostLikeApiSpec {
+
+    /// 좋아요
+    @Operation(
+            summary = "좋아요 생성 API",
+            description = "좋아요를 생성합니다."
+    )
+    ApiResponse<Void> like(
+            @RequestBody @Valid PostLikeRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+    /// 좋아요 취소
+    @Operation(
+            summary = "좋아요 취소 API",
+            description = "좋아요를 취소합니다."
+    )
+    ApiResponse<Void> unlike(
+            @Parameter(example = "1")
+            @RequestParam Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
@@ -92,8 +92,9 @@ public class UserService implements UserUseCase{
     // =================
     @Override
     @Transactional(readOnly = true)
-    public Optional<User> loadUser(Long userId) {
-        return repository.findByIdAndDeletedIsFalse(userId);
+    public User loadUser(Long userId) {
+        return repository.findByIdAndDeletedIsFalse(userId)
+                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 유저가 없습니다."));
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
@@ -92,7 +92,7 @@ public class UserService implements UserUseCase{
     // =================
     @Override
     @Transactional(readOnly = true)
-    public Optional<User> getUser(Long userId) {
+    public Optional<User> loadUser(Long userId) {
         return repository.findByIdAndDeletedIsFalse(userId);
     }
 

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -84,4 +85,15 @@ public class UserService implements UserUseCase{
     public boolean checkDuplicateNickName(String nickName) {
         return repository.existsByNickname(nickName);
     }
+
+
+    // =================
+    //  외부 조회 로직
+    // =================
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<User> getUser(Long userId) {
+        return repository.findByIdAndDeletedIsFalse(userId);
+    }
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserUseCase.java
@@ -21,6 +21,6 @@ public interface UserUseCase {
     void withdraw(Long userId);
 
     /// 외부 함수
-    Optional<User> loadUser(Long userId);
+    User loadUser(Long userId);
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserUseCase.java
@@ -21,6 +21,6 @@ public interface UserUseCase {
     void withdraw(Long userId);
 
     /// 외부 함수
-    Optional<User> getUser(Long userId);
+    Optional<User> loadUser(Long userId);
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserUseCase.java
@@ -1,7 +1,10 @@
 package bootcamp.kakao.community.platform.user.application;
 
 import bootcamp.kakao.community.platform.user.application.dto.SignUpRequest;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
 import bootcamp.kakao.community.security.jwt.application.dto.JwtTokenResponse;
+
+import java.util.Optional;
 
 public interface UserUseCase {
 
@@ -16,5 +19,8 @@ public interface UserUseCase {
 
     /// 회원 탈퇴
     void withdraw(Long userId);
+
+    /// 외부 함수
+    Optional<User> getUser(Long userId);
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/dto/UserResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/dto/UserResponse.java
@@ -1,5 +1,26 @@
 package bootcamp.kakao.community.platform.user.application.dto;
 
-public record UserResponse() {
+import bootcamp.kakao.community.platform.user.domain.entity.User;
+import lombok.Builder;
+
+@Builder
+public record UserResponse(
+        Long userId,
+        String name,
+        String imageUrl,
+        String nickname,
+        String email
+) {
+
+    /// 정적 팩토리 메서드
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .imageUrl(user.getImageUrl())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .build();
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/security/config/SecurityConfig.java
+++ b/src/main/java/bootcamp/kakao/community/security/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(AbstractHttpConfigurer::disable)
+                /// 인가
+                .authorizeHttpRequests(req -> req.requestMatchers("/**").permitAll())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) /// UsernamePasswordAuthenticationFilter.class 전에 실행하도록
                 .exceptionHandling(exception -> {
                     exception.authenticationEntryPoint(jwtFailureHandler)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,14 @@ auth:
       expiration: 86400000 # 1일
     refresh:
       expiration: 604800000 # 7일
+
+#### AWS
+cloud:
+  aws:
+    credentials:
+      access-key: ${ACCESS_KEY}
+      secret-key: ${SECRET_KEY}
+    S3:
+      bucket: ${BUCKET}
+    region:
+      static: ${STATIC}


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- S3 이미지 업로드/삭제 기능을 도메인별로 설계하여 커뮤니티 게시글 이미지 처리 기능을 구현했습니다.
-게시글 CRUD 기능과 이미지 기능 통합: 게시글 작성/수정 시 이미지 첨부 및 검증 기능 구현, 게시글 이미지 목록 조회 기능(무한 스크롤)도 포함.
- Swagger 문서 및 인가 Config, 무한스크롤 DTO 등 부가 기능과 코드 개선 적용.
- QueryDSL 조건절 BooleanBuilder, 서비스 코드명, 예외처리 위치 리팩터링 포함.
- 좋아요 서비스, 카테고리 기능 등 게시글 관련 추가 기능 및 도메인 구조 확장 작업도 포함.

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 이미지 파일명은 UUID와 확장자를 조합하여 중복 방지 및 안전한 저장이 가능합니다.
- 임시 이미지의 경우 사용자 정보 없이도 저장 가능하며, 이후 확정 시 사용자와 연동 처리합니다.
- 멀티 이미지 업로드 및 삭제 기능도 서비스 레이어에서 지원하여 유연성을 높였습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

- S3 URL발급 
<img width="1420" height="573" alt="image" src="https://github.com/user-attachments/assets/a38579c7-e948-4d9f-97f3-df64613de909" />

- 게시글 상세 조회 모습
```json
{
  "success": true,
  "code": 200,
  "message": "호출이 성공적으로 완료되었습니다.",
  "data": {
    "author": {
      "userId": 1,
      "name": "string",
      "imageUrl": "string",
      "nickname": "string",
      "email": "string"
    },
    "id": null,
    "category": "Q&A",
    "title": "예시",
    "content": "string",
    "likeCount": 0,
    "viewCount": 0,
    "commentCount": 0,
    "image": [
      {
        "imageUrl": "https://seeat-local-test.s3.ap-northeast-2.amazonaws.com/0c8d321d-afbe-4d7c-8105-c2bbc55bc8ab.ktb3-cloud?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20251003T173433Z&X-Amz-SignedHeaders=host&X-Amz-Expires=900&X-Amz-Credential=AKIATX3PHTSFES5NDT5K%2F20251003%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=fc3c53accdf1ae49467b273e2e7e937f21da08b6b1b3bfc1c93ba9eccc99bb7e",
        "order": 0
      }
    ],
    "liked": false,
    "editable": true,
    "createdAt": "2025-10-04T02:34:43.009745",
    "updatedAt": "2025-10-04T02:34:43.009745"
  }
}
```

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#7 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
