### PR TITLE
✨ feat : 댓글 기능 고도화

### DIFF
--- a/src/main/java/bootcamp/kakao/community/common/config/LocalSwaggerConfig.java
+++ b/src/main/java/bootcamp/kakao/community/common/config/LocalSwaggerConfig.java
@@ -31,7 +31,7 @@ public class LocalSwaggerConfig {
     public OpenApiCustomizer removeGenericSchemas() {
         return openApi -> {
             openApi.getComponents().getSchemas().keySet().removeIf(name ->
-                    name.contains("ApiResponse") || name.contains("SliceRequest") || name.contains("SliceResponse") || name.contains("FieldErrorResponse")
+                    name.contains("ApiResponse") || name.contains("SliceResponse") || name.contains("FieldErrorResponse")
             );
         };
     }

--- a/src/main/java/bootcamp/kakao/community/common/config/LocalSwaggerConfig.java
+++ b/src/main/java/bootcamp/kakao/community/common/config/LocalSwaggerConfig.java
@@ -31,7 +31,7 @@ public class LocalSwaggerConfig {
     public OpenApiCustomizer removeGenericSchemas() {
         return openApi -> {
             openApi.getComponents().getSchemas().keySet().removeIf(name ->
-                    name.contains("ApiResponse") || name.contains("SliceResponse")
+                    name.contains("ApiResponse") || name.contains("SliceRequest") || name.contains("SliceResponse") || name.contains("FieldErrorResponse")
             );
         };
     }

--- a/src/main/java/bootcamp/kakao/community/common/logging/LogAspect.java
+++ b/src/main/java/bootcamp/kakao/community/common/logging/LogAspect.java
@@ -1,4 +1,40 @@
 package bootcamp.kakao.community.common.logging;
 
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
 public class LogAspect {
+
+    @Pointcut("execution(* bootcamp.kakao.community.platform..*Service.*(..))")
+    private void applicationLayer() {
+    }
+
+    @Around("applicationLayer()")
+    public Object logProcessTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        Object proceed = joinPoint.proceed();  // 실제 메서드 실행
+
+        long executionTime = System.currentTimeMillis() - start;
+
+        /// 서비스명 추출하기
+        String declaringTypeName = joinPoint.getSignature().getDeclaringTypeName();
+        String[] split = declaringTypeName.split("\\.");
+        String serviceName = split[split.length - 1];
+
+        log.info("[서비스 로깅] 메서드 소요 시간: {}.{} = {}ms",
+                serviceName,
+                joinPoint.getSignature().getName(),
+                executionTime);
+
+        return proceed;
+    }
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageRequest.java
@@ -1,5 +1,10 @@
 package bootcamp.kakao.community.platform.images.image.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "[요청][이미지] 이미지 업로드 Request", description = "이미지 업로드를 위한 DTO입니다.")
 public record ImageRequest(
-        String file) {
+        @Schema(description = "이미지 파일(base64 인코딩)", example = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgA...")
+        String file
+) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageResponse.java
@@ -1,15 +1,18 @@
 package bootcamp.kakao.community.platform.images.image.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-/**
- * S3 이미지 DTO
- * @param fileName      원본 파일 이름
- * @param preSignedUrl  저장할 S3 주소
- */
+@Schema(
+        name = "[응답][이미지] 이미지 응답 Response",
+        description = "S3에 저장된 이미지 정보를 응답하기 위한 DTO입니다."
+)
 @Builder
 public record ImageResponse(
+        @Schema(description = "원본 파일 이름", example = "example-image.png")
         String fileName,
+
+        @Schema(description = "S3 저장 주소 (Pre-Signed URL)", example = "https://s3.amazonaws.com/bucket/example-image.png?X-Amz-Signature=...")
         String preSignedUrl) {
 
     /// 정적 팩토리 메서드

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/dto/PostImageResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/dto/PostImageResponse.java
@@ -1,12 +1,20 @@
 package bootcamp.kakao.community.platform.images.post_images.application.dto;
 
 import bootcamp.kakao.community.platform.images.post_images.domain.entity.PostImage;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import java.util.List;
 
+@Schema(
+        name = "[응답][포스트 이미지] 포스트 이미지 응답 Response",
+        description = "포스트 이미지 정보를 응답하는 DTO입니다."
+)
 @Builder
 public record PostImageResponse(
+        @Schema(description = "이미지 URL", example = "https://example.com/images/image1.png")
         String imageUrl,
+
+        @Schema(description = "이미지 노출 순서", example = "1")
         int order
 ) {
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/dto/CategoryRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/dto/CategoryRequest.java
@@ -1,11 +1,17 @@
 package bootcamp.kakao.community.platform.posts.category.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * @param parentId  상위 카테고리
  * @param name      카테고리 명
  */
+@Schema(name = "[요청][카테고리] 카테고리 등록 Request", description = "카테고리 등록을 위한 Request DTO입니다.")
 public record CategoryRequest(
+        @Schema(description = "상위 카테고리 ID", example = "null")
         Long parentId,
+
+        @Schema(description = "카테고리 명", example = "예시")
         String name
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
@@ -2,11 +2,12 @@ package bootcamp.kakao.community.platform.posts.comment.application;
 
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
+import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentListResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentRequest;
-import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentUpdateRequest;
 import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
 import bootcamp.kakao.community.platform.posts.comment.domain.repository.CommentRepository;
+import bootcamp.kakao.community.platform.posts.comment.domain.repository.dto.CommentWithChildren;
 import bootcamp.kakao.community.platform.posts.post.application.PostQueryUseCase;
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.user.application.UserUseCase;
@@ -56,29 +57,23 @@ public class CommentService implements CommentUseCase{
      */
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<CommentResponse> getComments(SliceRequest request, Long postId, Long userId) {
-
-
+    public SliceResponse<CommentListResponse> getComments(SliceRequest request, Long postId, Long userId) {
 
         /// 게시글 예외처리
         Post post = postService.loadPost(postId);
 
-        /// 가져오기
-        Slice<Comment> comments = repository.findCommentsByCursor(request, post.getId());
-
-        if (userId == null){
-            Slice<CommentResponse> var = CommentResponse.from(comments, userId);
-            return SliceResponse.from(var);
-        }
+        /// 가져오기 (부모 댓글과 대댓글 존재 )
+        Slice<CommentWithChildren> comments = repository.findCommentsByCursor(request, post.getId());
 
         /// 리턴
-        Slice<CommentResponse> var = CommentResponse.from(comments, userId);
+        Slice<CommentListResponse> var = CommentListResponse.from(comments, userId);
         return SliceResponse.from(var);
     }
 
+    /// 인기 게시글 조회하기
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<CommentResponse> getFavoriteComments(SliceRequest request, Long postId) {
+    public SliceResponse<CommentListResponse> getFavoriteComments(SliceRequest request, Long postId) {
 
         /// 게시글 예외처리
         Post post = postService.loadPost(postId);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
@@ -26,6 +26,7 @@ public class CommentService implements CommentUseCase{
     private final PostQueryUseCase postService;
     private final UserUseCase userService;
 
+    /// 댓글 생성
     @Override
     @Transactional
     public void createComment(CommentRequest request, Long userId) {
@@ -42,14 +43,22 @@ public class CommentService implements CommentUseCase{
             parent = loadComment(request.parentId());
         }
 
-        /// 객체 생성
-        Comment.of(post, user, parent, request.content());
-
+        /// 객체 생성 및 저장
+        var reqComment = Comment.of(post, user, parent, request.content());
+        repository.save(reqComment);
     }
 
+    /**
+     * 게시글에 따른 댓글 목록 조회
+     * @param request   Slice 요청 DTO
+     * @param postId    조회할 게시글
+     * @param userId    조회하는 유저 (편집 가능 여부 판단)
+     */
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<CommentResponse> getComments(SliceRequest request, Long postId) {
+    public SliceResponse<CommentResponse> getComments(SliceRequest request, Long postId, Long userId) {
+
+
 
         /// 게시글 예외처리
         Post post = postService.loadPost(postId);
@@ -57,14 +66,20 @@ public class CommentService implements CommentUseCase{
         /// 가져오기
         Slice<Comment> comments = repository.findCommentsByCursor(request, post.getId());
 
+        if (userId == null){
+            Slice<CommentResponse> var = CommentResponse.from(comments, userId);
+            return SliceResponse.from(var);
+        }
+
         /// 리턴
-        Slice<CommentResponse> var = CommentResponse.from(comments);
+        Slice<CommentResponse> var = CommentResponse.from(comments, userId);
         return SliceResponse.from(var);
     }
 
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<CommentResponse> getFavoriteComments(SliceRequest request, Long postId) {
+
         /// 게시글 예외처리
         Post post = postService.loadPost(postId);
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentUseCase.java
@@ -13,7 +13,7 @@ public interface CommentUseCase {
     void createComment(CommentRequest request, Long userId);
 
     /// 게시글에 따른 댓글 목록 조회 (무한스크롤)
-    SliceResponse<CommentResponse> getComments(SliceRequest request, Long postI);
+    SliceResponse<CommentResponse> getComments(SliceRequest request, Long postId, Long userId);
 
     /// 인기 댓글 목록 조회
     SliceResponse<CommentResponse> getFavoriteComments(SliceRequest request, Long postId);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentUseCase.java
@@ -2,8 +2,8 @@ package bootcamp.kakao.community.platform.posts.comment.application;
 
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
+import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentListResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentRequest;
-import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentUpdateRequest;
 import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
 
@@ -13,10 +13,10 @@ public interface CommentUseCase {
     void createComment(CommentRequest request, Long userId);
 
     /// 게시글에 따른 댓글 목록 조회 (무한스크롤)
-    SliceResponse<CommentResponse> getComments(SliceRequest request, Long postId, Long userId);
+    SliceResponse<CommentListResponse> getComments(SliceRequest request, Long postId, Long userId);
 
     /// 인기 댓글 목록 조회
-    SliceResponse<CommentResponse> getFavoriteComments(SliceRequest request, Long postId);
+    SliceResponse<CommentListResponse> getFavoriteComments(SliceRequest request, Long postId);
 
     /// 댓글 수정
     void updateComment(CommentUpdateRequest request, Long userId);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentListResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentListResponse.java
@@ -1,0 +1,55 @@
+package bootcamp.kakao.community.platform.posts.comment.application.dto;
+
+import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
+import bootcamp.kakao.community.platform.posts.comment.domain.repository.dto.CommentWithChildren;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+@Builder
+@Schema(name = "[응답][댓글] 댓글 목록 Response", description = "댓글 목록 조회를 위한 DTO입니다.")
+public record CommentListResponse(
+        @Schema(description = "루트 댓글")
+        CommentResponse root,
+
+        @Schema(description = "자식 댓글 리스트")
+        List<CommentResponse> children
+) {
+
+    /// 정적 팩토리 메서드
+    public static CommentListResponse from(CommentWithChildren withChildren, Long userId) {
+
+        Comment root = withChildren.root();
+        List<Comment> children = withChildren.children();
+
+        /// 루트
+        CommentResponse rootResponse = CommentResponse.from(root, userId);
+
+        /// 자식
+        List<CommentResponse> childResponse = children.stream()
+                .map(c -> CommentResponse.from(c, userId))
+                .toList();
+
+        return CommentListResponse.builder()
+                .root(rootResponse)
+                .children(childResponse)
+                .build();
+    }
+
+    /// 정적 팩토리 메서드
+    public static Slice<CommentListResponse> from(Slice<CommentWithChildren> withChildren, Long userId) {
+
+        /// 리스트
+        List<CommentListResponse> responses = withChildren.stream()
+                .map(c -> CommentListResponse.from(c, userId))
+                .toList();
+
+        /// 리턴
+        return new SliceImpl<>(responses, withChildren.getPageable(), withChildren.hasNext());
+
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentRequest.java
@@ -1,8 +1,16 @@
 package bootcamp.kakao.community.platform.posts.comment.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "[요청][댓글] 댓글 등록 Request", description = "댓글 등록을 위한 DTO입니다.")
 public record CommentRequest(
+        @Schema(description = "부모 댓글 아이디", example = "null")
         Long parentId,
+
+        @Schema(description = "게시글 아이디", example = "1")
         Long postId,
+
+        @Schema(description = "댓글 내용", example = "이 글에 공감합니다!")
         String content
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentResponse.java
@@ -18,6 +18,9 @@ public record CommentResponse(
         @Schema(description = "댓글 작성자 정보")
         UserResponse user,
 
+        @Schema(description = "댓글 아이디", example = "1")
+        long id,
+
         @Schema(description = "부모 댓글 아이디", example = "null")
         Long parentId,
 
@@ -31,6 +34,14 @@ public record CommentResponse(
     /// 정적 팩토리 메서드
     public static CommentResponse from(Comment comment, Long userId) {
 
+        /// 삭제 여부 체크
+        String content;
+        if (comment.isDeleted()) {
+            content = "삭제된 메시지입니다.";
+        } else {
+            content = comment.getContent();
+        }
+
         /// 수정 가능 여부, 기본 값 설정
         boolean editable = false;
 
@@ -43,8 +54,9 @@ public record CommentResponse(
 
         return CommentResponse.builder()
                 .user(UserResponse.from(comment.getUser()))
+                .id(comment.getId())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
-                .content(comment.getContent())
+                .content(content)
                 .editable(editable)
                 .build();
     }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentResponse.java
@@ -29,19 +29,32 @@ public record CommentResponse(
 ) {
 
     /// 정적 팩토리 메서드
-    public static CommentResponse from(Comment comment) {
+    public static CommentResponse from(Comment comment, Long userId) {
+
+        /// 수정 가능 여부, 기본 값 설정
+        boolean editable = false;
+
+        /// 로그인된 상태 + 유저 일치
+        if (userId != null
+                && comment.getUser() != null
+                && userId.equals(comment.getUser().getId())) {
+            editable = true;
+        }
+
         return CommentResponse.builder()
                 .user(UserResponse.from(comment.getUser()))
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
                 .content(comment.getContent())
+                .editable(editable)
                 .build();
     }
 
-    public static Slice<CommentResponse> from(Slice<Comment> posts) {
+    /// 정적 팩토리 메서드 반복
+    public static Slice<CommentResponse> from(Slice<Comment> posts, Long userId) {
 
         /// 값 생성
         List<CommentResponse> commentResponses = posts.stream()
-                .map(CommentResponse::from)
+                .map(comment -> CommentResponse.from(comment, userId))
                 .toList();
 
         /// Slice 객체 생성

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentResponse.java
@@ -2,18 +2,29 @@ package bootcamp.kakao.community.platform.posts.comment.application.dto;
 
 import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
 import bootcamp.kakao.community.platform.user.application.dto.UserResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
+@Schema(
+        name = "[응답][댓글] 댓글 응답 Response",
+        description = "댓글 정보를 응답하기 위한 DTO입니다."
+)
 @Builder
 public record CommentResponse(
-
+        @Schema(description = "댓글 작성자 정보")
         UserResponse user,
+
+        @Schema(description = "부모 댓글 아이디", example = "null")
         Long parentId,
+
+        @Schema(description = "댓글 본문", example = "정말 좋은 게시글이네요!")
         String content,
+
+        @Schema(description = "댓글 수정 가능 여부", example = "true")
         boolean editable
 ) {
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentUpdateRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentUpdateRequest.java
@@ -1,7 +1,13 @@
 package bootcamp.kakao.community.platform.posts.comment.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "[요청][댓글] 댓글 수정 Request", description = "댓글 수정을 위한 DTO입니다.")
 public record CommentUpdateRequest(
+        @Schema(description = "댓글 아이디", example = "1")
         Long id,
+
+        @Schema(description = "수정할 댓글 내용", example = "수정된 댓글 내용입니다.")
         String content
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/entity/Comment.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/entity/Comment.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(name = "comments")
+@Table(name = "comments", indexes = {@Index(name = "idx_comment_",columnList = "parent_id, deleted")})
 public class Comment extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustom.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustom.java
@@ -1,7 +1,7 @@
 package bootcamp.kakao.community.platform.posts.comment.domain.repository;
 
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
-import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
+import bootcamp.kakao.community.platform.posts.comment.domain.repository.dto.CommentWithChildren;
 import org.springframework.data.domain.Slice;
 
 public interface CommentRepositoryCustom {
@@ -11,6 +11,6 @@ public interface CommentRepositoryCustom {
      * @param sliceRequest  슬라이싱 요청
      * @param postId        게시글 ID
      */
-    Slice<Comment> findCommentsByCursor(SliceRequest sliceRequest, Long postId);
+    Slice<CommentWithChildren> findCommentsByCursor(SliceRequest sliceRequest, Long postId);
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package bootcamp.kakao.community.platform.posts.comment.domain.repository;
 
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
+import bootcamp.kakao.community.platform.posts.comment.domain.repository.dto.CommentWithChildren;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +13,9 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 import static bootcamp.kakao.community.platform.posts.comment.domain.entity.QComment.comment;
-import static bootcamp.kakao.community.platform.posts.post.domain.entity.QPost.post;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,30 +23,63 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    /// 고민해보다가, 매핑하는 부분에서GPT의 도움을 좀 받았습니다 ㅠㅠ
     @Override
-    public Slice<Comment> findCommentsByCursor(SliceRequest sliceRequest, Long postId) {
+    public Slice<CommentWithChildren> findCommentsByCursor(SliceRequest sliceRequest, Long postId) {
 
         /// QueryDSL 조회
         /// 기존 댓글(루트 댓글) + 대댓글까지 한번에 가져오게 하려면?
         /// 1차로 루트 먼저 가져오게끔
         /// 2차로 해당 루트의 자식 댓글 가져오게끔
 
-        List<Comment> fetch = queryFactory
+        /// 1차
+        List<Comment> rootComments = queryFactory
                 .selectFrom(comment)
                 .where(
                         eqPostId(postId),
                         ltLastId(sliceRequest.lastId()),
                         comment.parent.isNull())    /// 루트 댓글만 조회
-                .orderBy(post.id.desc())
+                .orderBy(comment.id.desc())
                 .limit(sliceRequest.offSet() + 1) // hasNext 확인용 +1
                 .fetch();
 
+        // 루트 순서 보존용(LinkedHashMap) + id 목록
+        List<Long> rootIds = rootComments.stream().map(Comment::getId).toList();
+
+        /// 2차
+        List<Comment> childComments = queryFactory
+                .selectFrom(comment)
+                .where(
+                        comment.parent.id.in(rootIds),   /// 루트 댓글이 있는 것만 가져오도록
+                        eqPostId(postId)        /// 게시글 ID 가져오기
+                )
+                .orderBy(comment.parent.id.asc(), comment.id.asc())
+                .fetch();
+
+        /// 매핑 시키기 (GPT 도움 ..)
+        // parentId를 바탕으로 children 리스트로 그룹핑
+        Map<Long, List<Comment>> childrenByParentId = childComments.stream()
+                .collect(java.util.stream.Collectors.groupingBy(
+                        c -> c.getParent().getId(),
+                        java.util.LinkedHashMap::new,
+                        java.util.stream.Collectors.toList()
+                ));
+
+        /// List 매핑
+        List<CommentWithChildren> mappedComments = rootComments.stream()
+                .map(root -> CommentWithChildren.from(
+                        root,
+                        childrenByParentId.getOrDefault(root.getId(), List.of())
+                ))
+                .toList();
+        /// 도움 끝
+
         /// Slice 객체 생성
         boolean hasNext = false;
-        if (fetch.size() > sliceRequest.offSet()) {
+        if (rootComments.size() > sliceRequest.offSet()) {
 
             /// 조회했던 값은 삭제
-            fetch.remove(sliceRequest.offSet());
+            rootComments.remove(sliceRequest.offSet());
             hasNext = true;
         }
 
@@ -53,7 +87,8 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         Pageable pageable = PageRequest.of(0, sliceRequest.offSet());
 
         /// 리턴
-        return new SliceImpl<>(fetch, pageable, hasNext);
+        return new SliceImpl<>(mappedComments, pageable, hasNext);
+
     }
 
     /// 커서 조건 (id 기반 커서)

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustomImpl.java
@@ -4,6 +4,7 @@ import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
 import bootcamp.kakao.community.platform.posts.comment.domain.repository.dto.CommentWithChildren;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -33,14 +34,31 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         /// 2차로 해당 루트의 자식 댓글 가져오게끔
 
         /// 1차
+        var child = new bootcamp.kakao.community.platform.posts.comment.domain.entity.QComment("child");
+
         List<Comment> rootComments = queryFactory
                 .selectFrom(comment)
                 .where(
                         eqPostId(postId),
                         ltLastId(sliceRequest.lastId()),
-                        comment.parent.isNull())    /// 루트 댓글만 조회
+                        comment.parent.isNull(),
+                        // 삭제 필터: (not deleted) OR (deleted AND exists(not-deleted child))
+                        comment.deleted.isFalse()
+                                .or(
+                                        comment.deleted.isTrue()
+                                                .and(
+                                                        JPAExpressions.selectOne()
+                                                                .from(child)
+                                                                .where(
+                                                                        child.parent.id.eq(comment.id),
+                                                                        child.deleted.isFalse()
+                                                                )
+                                                                .exists()
+                                                )
+                                )
+                )
                 .orderBy(comment.id.desc())
-                .limit(sliceRequest.offSet() + 1) // hasNext 확인용 +1
+                .limit(sliceRequest.offSet() + 1) // hasNext 판별용 +1
                 .fetch();
 
         // 루트 순서 보존용(LinkedHashMap) + id 목록
@@ -51,7 +69,8 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                 .selectFrom(comment)
                 .where(
                         comment.parent.id.in(rootIds),   /// 루트 댓글이 있는 것만 가져오도록
-                        eqPostId(postId)        /// 게시글 ID 가져오기
+                        eqPostId(postId),        /// 게시글 ID 가져오기
+                        comment.deleted.isFalse()
                 )
                 .orderBy(comment.parent.id.asc(), comment.id.asc())
                 .fetch();

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/dto/CommentWithChildren.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/dto/CommentWithChildren.java
@@ -1,0 +1,23 @@
+package bootcamp.kakao.community.platform.posts.comment.domain.repository.dto;
+
+import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
+import lombok.Builder;
+import java.util.List;
+
+/// 댓글과 해당하는 대댓글 조회하기
+@Builder
+public record CommentWithChildren(
+        Comment root,
+        List<Comment> children
+) {
+
+    /// 정적 팩토리 메서드
+    public static CommentWithChildren from(Comment root, List<Comment> children) {
+        return CommentWithChildren.builder()
+                .root(root)
+                .children(children)
+                .build();
+    }
+    
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/CommentApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/CommentApi.java
@@ -39,11 +39,15 @@ public class CommentApi implements CommentApiSpec {
     @GetMapping
     public ApiResponse<SliceResponse<CommentResponse>> listComments(
             SliceRequest sliceRequest,
-            @RequestParam Long postId
+            @RequestParam Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
 
+        /// 유저가 없다면 null 저장
+        Long userId = customUserDetails != null ? customUserDetails.getId() : null;
+
         /// 서비스 실행
-        SliceResponse<CommentResponse> response = service.getComments(sliceRequest, postId);
+        SliceResponse<CommentResponse> response = service.getComments(sliceRequest, postId, userId);
 
         /// 리턴
         return ApiResponse.ok(response);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/CommentApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/CommentApi.java
@@ -4,6 +4,7 @@ import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.CommentUseCase;
+import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentListResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentRequest;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentUpdateRequest;
@@ -37,7 +38,7 @@ public class CommentApi implements CommentApiSpec {
 
     /// 게시글에 따른 댓글 조회
     @GetMapping
-    public ApiResponse<SliceResponse<CommentResponse>> listComments(
+    public ApiResponse<SliceResponse<CommentListResponse>> listComments(
             SliceRequest sliceRequest,
             @RequestParam Long postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
@@ -47,7 +48,7 @@ public class CommentApi implements CommentApiSpec {
         Long userId = customUserDetails != null ? customUserDetails.getId() : null;
 
         /// 서비스 실행
-        SliceResponse<CommentResponse> response = service.getComments(sliceRequest, postId, userId);
+        SliceResponse<CommentListResponse> response = service.getComments(sliceRequest, postId, userId);
 
         /// 리턴
         return ApiResponse.ok(response);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/swagger/CommentApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/swagger/CommentApiSpec.java
@@ -33,7 +33,9 @@ public interface CommentApiSpec {
     )
     ApiResponse<SliceResponse<CommentResponse>> listComments(
             SliceRequest sliceRequest,
-            @RequestParam Long postId);
+            @RequestParam Long postId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
 
 
     /// 댓글 수정

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/swagger/CommentApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/swagger/CommentApiSpec.java
@@ -3,6 +3,7 @@ package bootcamp.kakao.community.platform.posts.comment.presentation.swagger;
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
+import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentListResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentRequest;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentUpdateRequest;
@@ -31,7 +32,7 @@ public interface CommentApiSpec {
             summary = "댓글 조회 API",
             description = "게시글에 따른 댓글을 조회하는 API 입니다."
     )
-    ApiResponse<SliceResponse<CommentResponse>> listComments(
+    ApiResponse<SliceResponse<CommentListResponse>> listComments(
             SliceRequest sliceRequest,
             @RequestParam Long postId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
@@ -1,5 +1,6 @@
 package bootcamp.kakao.community.platform.posts.post.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -12,6 +13,7 @@ import java.util.List;
  * @param content       내용
  * @param imageUrls     이미지 URLs
  */
+@Schema(name = "[요청][게시글] 게시글 생성 Request", description = "게시글 생성을 위한 요청 DTO입니다.")
 public record PostRequest(
 
         @NotNull(message = "카테고리없이 게시글을 작성할 수 없습니다.")

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
@@ -1,12 +1,24 @@
 package bootcamp.kakao.community.platform.posts.post.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "[요청][게시글] 게시글 수정 Request", description = "게시글 수정을 위한 요청 DTO입니다.")
 public record PostUpdateRequest(
+        @Schema(description = "게시글 ID", example = "1")
         Long id,
+
+        @Schema(description = "카테고리 ID", example = "1001")
         Long categoryId,
+
+        @Schema(description = "제목", example = "수정된 게시글 제목")
         String title,
+
+        @Schema(description = "내용", example = "수정된 게시글 내용")
         String content,
+
+        @Schema(description = "첨부 이미지 URL 리스트", example = "[\"https://example.com/image1.png\", \"https://example.com/image2.png\"]")
         List<String> imageUrls
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/report/application/dto/ReportRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/report/application/dto/ReportRequest.java
@@ -1,10 +1,17 @@
 package bootcamp.kakao.community.platform.report.application.dto;
 
 import bootcamp.kakao.community.platform.report.domain.entity.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "[요청][신고] 신고 요청 Request", description = "신고를 위한 요청 DTO입니다.")
 public record ReportRequest(
+        @Schema(description = "신고 유형", example = "유저")
         ReportType type,
+
+        @Schema(description = "신고 대상 콘텐츠 ID", example = "1")
         Long contentId,
+
+        @Schema(description = "신고 사유", example = "부적절한 내용 포함")
         String reason
 ) {
 

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
@@ -62,16 +62,31 @@ public class UserService implements UserUseCase{
             throw new IllegalArgumentException("패스워드가 일치하지 않는 문제입니다.");
         }
 
-        /// 객체 생성 후, 저장
-        var requestUser = User.of(request.name(), request.imageUrl(), request.nickname(), request.email(), passwordEncoder.encode(request.password()));
-        User user = repository.save(requestUser);
+        User user;
 
-        /// 이미지가 존재하는지 확인 및 매핑시키기 (트랜잭션 & 영속성 컨텍스트)
-        /// 여기서 에러가 나면, 회원가입 전부 롤백
-        Image image = imageService.getImage(request.imageUrl());
+        /// 이미지가 존재한다면,
+        if (request.imageUrl() != null) {
 
-        /// 이미지 상태를 확정 (더티체킹)
-        image.confirm(user);
+            String imageUrl = request.imageUrl();
+
+            /// 이미지가 존재하는지 확인 및 매핑시키기 (트랜잭션 & 영속성 컨텍스트)
+            /// 여기서 에러가 나면, 회원가입 전부 롤백
+            Image image = imageService.getImage(imageUrl);
+
+            /// 객체 생성 후, 저장
+            var requestUser = User.of(request.name(), imageUrl, request.nickname(), request.email(), passwordEncoder.encode(request.password()));
+            user = repository.save(requestUser);
+
+            /// 이미지 상태를 확정 (더티체킹)
+            image.confirm(user);
+
+        } else {
+            /// 이미지가 없다면,
+            /// 객체 생성 후, 저장
+            var requestUser = User.of(request.name(), null, request.nickname(), request.email(), passwordEncoder.encode(request.password()));
+            user = repository.save(requestUser);
+
+        }
 
         /// 로그인했다면, JWT 발급하기
         var jwtRequest = JwtTokenRequest.from(user);

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/dto/SignUpRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/dto/SignUpRequest.java
@@ -4,11 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 @Schema(name = "[요청][유저] 회원가입 Request", description = "회원가입을 위한 DTO입니다.")
 public record SignUpRequest(
+
+        @Schema(example = "이도연")
         String name,
+
+        @Schema(example = "null")
         String imageUrl,
 
         @NotBlank(message = "닉네임을 입력해주세요. (띄어쓰기 불가)")
         @Size(max = 10, message = "닉네임은 10글자 이내입니다.")
+        @Schema(example = "david")
         String nickname,
 
         @NotBlank(message = "이메일을 입력해주세요.")

--- a/src/main/java/bootcamp/kakao/community/security/auth/application/dto/LoginRequest.java
+++ b/src/main/java/bootcamp/kakao/community/security/auth/application/dto/LoginRequest.java
@@ -1,7 +1,13 @@
 package bootcamp.kakao.community.security.auth.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "[요청][인증] 로그인 Request", description = "로그인 요청을 위한 DTO입니다.")
 public record LoginRequest(
+        @Schema(description = "사용자 이메일", example = "ktbcloud@kakao.com")
         String email,
+
+        @Schema(description = "사용자 비밀번호", example = "Hello123!World")
         String password
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         auto_quote_keyword: false
@@ -24,6 +24,12 @@ spring:
         format_sql: false
         show_sql: false
     open-in-view: false
+
+  ### 카테고리 SQL 실행
+  sql:
+    init:
+      mode: always
+      platform: mysql
 
   ### 레디스 설정
   data:


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- application.yml에 SQL 조건 추가 및 Hibernate 관련 설정 적용
- 유저 Swagger 주석 추가 및 API 문서화 향상 
- 회원가입 이미지 분기 처리
- 댓글 관련 DTO, 수정/삭제 여부 판단, 계층 구현 등 주요 기능 향상 

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 처음 루트 댓글을 가져올 때 2가지의 케이스로 분류하여 가져오기에 성능상 문제가 존재  (메서드 소요시간이 최대 530ms까지 저하)
- 루트댓글 삭제X -> 가져온다 
- 루트댓글 삭제O -> 자식댓글이 있다면 가져온다.
- 루트댓글 삭제O -> 자식댓글이 없다면 가져오지않는다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

- 단일 댓글
<img width="887" height="701" alt="image" src="https://github.com/user-attachments/assets/5fba727f-8926-459f-b3fb-80ba664dec21" />


- 대댓글 (상위 댓글 삭제 시,)
<img width="887" height="701" alt="image" src="https://github.com/user-attachments/assets/21b5fd8b-53d9-4d01-b6cd-8a12a196864f" />


## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#16 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
