### PR TITLE
✨feat : leftJoin으로 성능 향상

### DIFF
--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/domain/repository/CommentRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package bootcamp.kakao.community.platform.posts.comment.domain.repository;
 
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.platform.posts.comment.domain.entity.Comment;
+import bootcamp.kakao.community.platform.posts.comment.domain.entity.QComment;
 import bootcamp.kakao.community.platform.posts.comment.domain.repository.dto.CommentWithChildren;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.JPAExpressions;
@@ -17,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 
 import static bootcamp.kakao.community.platform.posts.comment.domain.entity.QComment.comment;
-
 @Repository
 @RequiredArgsConstructor
 public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
@@ -33,33 +33,29 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         /// 1차로 루트 먼저 가져오게끔
         /// 2차로 해당 루트의 자식 댓글 가져오게끔
 
-        /// 1차
-        var child = new bootcamp.kakao.community.platform.posts.comment.domain.entity.QComment("child");
+        // 루트 댓글과 자식 댓글 존재 여부를 left join 해 존재하는지 판단
+        QComment child = new QComment("child");
 
+        /// 1차
         List<Comment> rootComments = queryFactory
                 .selectFrom(comment)
+                .leftJoin(child).on(child.parent.id.eq(comment.id), child.deleted.isFalse())
                 .where(
                         eqPostId(postId),
                         ltLastId(sliceRequest.lastId()),
                         comment.parent.isNull(),
-                        // 삭제 필터: (not deleted) OR (deleted AND exists(not-deleted child))
                         comment.deleted.isFalse()
-                                .or(
-                                        comment.deleted.isTrue()
-                                                .and(
-                                                        JPAExpressions.selectOne()
-                                                                .from(child)
-                                                                .where(
-                                                                        child.parent.id.eq(comment.id),
-                                                                        child.deleted.isFalse()
-                                                                )
-                                                                .exists()
-                                                )
-                                )
+                                .or(comment.deleted.isTrue().and(child.id.isNotNull()))
                 )
+                .groupBy(comment.id)
                 .orderBy(comment.id.desc())
-                .limit(sliceRequest.offSet() + 1) // hasNext 판별용 +1
+                .limit(sliceRequest.offSet() + 1)
                 .fetch();
+
+        /// 없으면 그대로 리턴
+        if (rootComments.isEmpty()) {
+            return new SliceImpl<>(List.of(), PageRequest.of(0, sliceRequest.offSet()), false);
+        }
 
         // 루트 순서 보존용(LinkedHashMap) + id 목록
         List<Long> rootIds = rootComments.stream().map(Comment::getId).toList();


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- CommentRepositoryCustomImpl.java에서 댓글 조회 시 leftJoin을 이용하여 성능 향상 적용
- 자식 댓글 존재 여부를 leftJoin으로 확인하여 불필요한 서브쿼리 제거
- 기존 540ms에서 347ms로 응답 속도 개선

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- leftJoin을 통해 삭제된 댓글이지만 자식 댓글이 존재하는 경우도 정상 처리하도록 로직 수정
- 페이징 처리 및 정렬은 기존 방식 유지

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="887" height="70" alt="image" src="https://github.com/user-attachments/assets/7017d175-356f-4ea8-9f9e-10a97f2ae6b8" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#16 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
