### PR TITLE
✨feat : 게시글 고도화

### DIFF
--- a/src/main/java/bootcamp/kakao/community/common/config/RedisConfig.java
+++ b/src/main/java/bootcamp/kakao/community/common/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -38,6 +39,7 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisConfig, clientConfig);
     }
 
+    /// RedisTemplate
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
@@ -48,6 +50,12 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
 
+    }
+
+    /// key-value 모두 String
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
+        return new StringRedisTemplate(cf);
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/common/util/KeyUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/util/KeyUtil.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class KeyUtil {
 
-    /// 개별 키 목록
+    /// 공통 키
     private static final String SEPARATOR = ":";
     private static final String DELIMITER = "-";
 
@@ -13,23 +13,40 @@ public class KeyUtil {
     private static final String POST = "post";
     private static final String VIEW = "view";
 
+    /// 댓글
+    private static final String COMMENT = "comment";
+
+    /// 좋아요
+    private static final String LIKES = "likes";
+
     /// JWT
     public static final String REFRESH_TOKEN = "refresh_token";
     public static final String ACCESS_TOKEN = "access_token";
     public static final String ID_CLAIM = "user_id";
-    public static final String EMAIL_CLAIM = "email";
     public static final String ROLE_CLAIM = "role";
 
-    /// 합쳐서 사용하는 키 목록
+    // =====================
+    //  합쳐서 사용하는 키 목록
+    // =====================
 
     /// 키 생성 함수
     public static String getRefreshTokenKey(Long userId, String deviceType) {
         return REFRESH_TOKEN + SEPARATOR + userId + SEPARATOR + deviceType;
     }
 
+    /// 게시글 조회수 키 생성 함수
     public static String getPostView(Long postId) {
         return POST + DELIMITER + VIEW + SEPARATOR + postId;
     }
 
+    /// 게시글 댓글수 키 생성 함수
+    public static String getPostComment(Long postId) {
+        return POST + DELIMITER + COMMENT + SEPARATOR + postId;
+    }
+
+    /// 게시글 좋아요수 키 생성 함수
+    public static String getPostLike(Long postId) {
+        return POST + DELIMITER + LIKES + SEPARATOR + postId;
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/batch/BatchApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/batch/BatchApi.java
@@ -1,0 +1,44 @@
+package bootcamp.kakao.community.platform.batch;
+
+import bootcamp.kakao.community.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/v1/test/batch")
+@RequiredArgsConstructor
+public class BatchApi implements BatchApiSpec{
+
+    private final PostBatchService postBatchService;
+    private final ImageBatchService imageBatchService;
+
+    /**
+     * 이미지 삭제 배치 프로세스
+     */
+    @PostMapping("/images")
+    public ApiResponse<Void> batchImages() throws IOException {
+
+        /// 서비스
+        imageBatchService.deleteBatchEveryDay();
+
+        /// 리턴
+        return ApiResponse.created();
+    }
+
+    /**
+     * 게시글 매핑 프로세스
+     */
+    @PostMapping("/post")
+    public ApiResponse<Void> batchPost() {
+
+        /// 서비스
+        postBatchService.syncPostStatsToDB();
+
+        /// 리턴
+        return ApiResponse.created();
+    }
+}

--- a/src/main/java/bootcamp/kakao/community/platform/batch/BatchApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/batch/BatchApiSpec.java
@@ -1,0 +1,25 @@
+package bootcamp.kakao.community.platform.batch;
+
+import bootcamp.kakao.community.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.io.IOException;
+
+@Tag(name = "테스트용 배치 API", description = "작동여부 파악을 위한 테스트용, 배치 API 입니다")
+public interface BatchApiSpec {
+
+    @Operation(
+            summary = "이미지 삭제 배치 API",
+            description = "S3에서 사용하지 않는 이미지를 삭제합니다."
+    )
+    ApiResponse<Void> batchImages() throws IOException;
+
+
+    @Operation(
+            summary = "게시글 매핑 API",
+            description = "레디스의 값을 DB에 매핑합니다."
+    )
+    ApiResponse<Void> batchPost();
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/batch/ImageBatchService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/batch/ImageBatchService.java
@@ -1,4 +1,4 @@
-package bootcamp.kakao.community.platform.images.image.application;
+package bootcamp.kakao.community.platform.batch;
 
 import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
 import bootcamp.kakao.community.platform.images.image.domain.repository.ImageRepository;
@@ -6,6 +6,7 @@ import bootcamp.kakao.community.platform.images.image.external.ImageCloudUseCase
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,6 +23,7 @@ public class ImageBatchService {
     private final ImageRepository repository;
 
     /// 3시마다 삭제 프로세싱
+    @Transactional
     @Scheduled(cron = "0 0 3 * * *")
     public void deleteBatchEveryDay() throws IOException {
 

--- a/src/main/java/bootcamp/kakao/community/platform/batch/PostBatchService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/batch/PostBatchService.java
@@ -1,0 +1,73 @@
+package bootcamp.kakao.community.platform.batch;
+
+import bootcamp.kakao.community.common.util.KeyUtil;
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 게시글의 조회수,댓글수, 좋아요수는 매일마다 DB에 백업 매핑해두록
+ */
+@Component
+@RequiredArgsConstructor
+public class PostBatchService {
+
+    /// 값 매핑
+    private final PostRepository repository;
+
+    /// 레디스
+    private final StringRedisTemplate redisTemplate;
+
+    /// 레디스에 조회한 내용을 DB에 연동하기
+    @Transactional
+    @Scheduled(cron = "0 0 6 * * *")
+    public void updateBatchEveryDays() {
+
+        /// DB에서 모든 게시글 목록 조회 (영속성 컨테이너)
+        List<Post> postList = repository.findAll();
+
+        /// Redis에서 한번에 조회할 키 목록 생성
+        List<String> viewCountKeys = postList.stream()
+                .map(p -> KeyUtil.getPostView(p.getId()))
+                .toList();
+
+        List<String> commentCountKeys = postList.stream()
+                .map(p -> KeyUtil.getPostComment(p.getId()))
+                .toList();
+
+        List<String> likeCountKeys = postList.stream()
+                .map(p -> KeyUtil.getPostLike(p.getId()))
+                .toList();
+
+        /// Redis에 multiGet 요청으로 데이터 한번에 가져오기
+        List<String> viewCounts = redisTemplate.opsForValue().multiGet(viewCountKeys);
+        List<String> commentCounts = redisTemplate.opsForValue().multiGet(commentCountKeys);
+        List<String> likeCounts = redisTemplate.opsForValue().multiGet(likeCountKeys);
+
+        /// 매번 반복
+        for (int i = 0; i < postList.size(); i++) {
+            Post post = postList.get(i);
+
+            // Redis에서 가져온 값
+            String redisViewCount = viewCounts.get(i);
+            String redisCommentCount = commentCounts.get(i);
+            String redisLikeCount = likeCounts.get(i);
+
+            // Redis에 값이 없으면 DB의 PostStat 값 사용
+            Long finalViewCount = (redisViewCount != null) ? Long.parseLong(redisViewCount) : post.getPostStat().getViewCount();
+            Long finalCommentCount = (redisCommentCount != null) ? Long.parseLong(redisCommentCount) : post.getPostStat().getCommentCount();
+            Long finalLikeCount = (redisLikeCount != null) ? Long.parseLong(redisLikeCount) : post.getPostStat().getLikeCount();
+
+            /// 추가
+            post.getPostStat().updateStat(finalCommentCount, finalLikeCount, finalViewCount);
+        }
+
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/batch/PostBatchService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/batch/PostBatchService.java
@@ -4,70 +4,136 @@ import bootcamp.kakao.community.common.util.KeyUtil;
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
-/**
- * 게시글의 조회수,댓글수, 좋아요수는 매일마다 DB에 백업 매핑해두록
- */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PostBatchService {
 
-    /// 값 매핑
     private final PostRepository repository;
-
-    /// 레디스
     private final StringRedisTemplate redisTemplate;
+    private static final int CHUNK_SIZE = 100;
 
-    /// 레디스에 조회한 내용을 DB에 연동하기
+    /**
+     * 매일 오전 4시에 Redis의 게시글 통계 정보를 DB에 업데이트하고, 처리된 Redis 키를 삭제합니다.
+     * CHUNK_SIZE 만큼 트랜잭션을 유지하고자 합니다.
+     */
     @Transactional
-    @Scheduled(cron = "0 0 6 * * *")
-    public void updateBatchEveryDays() {
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    public void syncPostStatsToDB() {
 
-        /// DB에서 모든 게시글 목록 조회 (영속성 컨테이너)
-        List<Post> postList = repository.findAll();
+        log.info("[배치 로깅] 게시글 통계 DB 동기화 및 Redis 키 삭제 배치 작업을 시작합니다.");
 
-        /// Redis에서 한번에 조회할 키 목록 생성
+        Page<Post> currentPage = null;
+        Pageable pageable = PageRequest.of(0, CHUNK_SIZE);
+
+        do {
+            try {
+                /// Chunk 단위로 데이터를 조회하고 DB에 업데이트합니다.
+                currentPage = updatePostStatsInChunk(pageable);
+
+                /// DB 업데이트가 성공한 Chunk의 Redis 키들을 삭제합니다.
+                if (currentPage != null && !currentPage.getContent().isEmpty()) {
+                    List<Post> processedPosts = currentPage.getContent();
+                    List<String> keysToDelete = new ArrayList<>();
+
+                    /// 삭제할 키를 리스트에 추가
+                    processedPosts.forEach(post -> {
+                        keysToDelete.add(KeyUtil.getPostView(post.getId()));
+                        keysToDelete.add(KeyUtil.getPostComment(post.getId()));
+                        keysToDelete.add(KeyUtil.getPostLike(post.getId()));
+                    });
+
+                    /// 한번에 키 삭제
+                    redisTemplate.delete(keysToDelete);
+                    log.info("[배치 로깅] Page {}의 Redis 키 {}개를 성공적으로 삭제했습니다.", pageable.getPageNumber(), keysToDelete.size());
+                }
+
+                /// 다음 페이지로 이동
+                pageable = currentPage.nextPageable();
+
+            } catch (Exception e) {
+                log.error("[배치 로깅] 게시글 통계 동기화 중 오류 발생. page: {}", pageable.getPageNumber(), e);
+
+                /// 오류 발생 시 해당 Chunk는 건너뛰고 다음으로 진행
+                if (pageable.getPageNumber() > 0) {
+                    pageable = pageable.next();
+                } else {
+                    break; // 첫 페이지에서 에러나면 중단
+                }
+            }
+        } while (currentPage != null && !currentPage.isLast());
+
+        log.info("[배치 로깅] 게시글 통계 DB 동기화 및 Redis 키 삭제 배치 작업을 성공적으로 완료했습니다.");
+    }
+
+    /**
+     * 한 페이지(Chunk) 단위로 게시글 통계를 처리합니다.
+     */
+    @Transactional
+    public Page<Post> updatePostStatsInChunk(Pageable pageable) {
+
+        /// 페이징에 해당하는 것 다 가져오기
+        Page<Post> postPage = repository.findAll(pageable);
+        List<Post> postList = postPage.getContent();
+
+        if (postList.isEmpty()) {
+            return postPage;
+        }
+
+        /// 조회수
         List<String> viewCountKeys = postList.stream()
                 .map(p -> KeyUtil.getPostView(p.getId()))
                 .toList();
 
+        /// 댓글수
         List<String> commentCountKeys = postList.stream()
                 .map(p -> KeyUtil.getPostComment(p.getId()))
                 .toList();
 
+        /// 좋아요수
         List<String> likeCountKeys = postList.stream()
                 .map(p -> KeyUtil.getPostLike(p.getId()))
                 .toList();
 
-        /// Redis에 multiGet 요청으로 데이터 한번에 가져오기
+        /// 순서대로 가져오기
         List<String> viewCounts = redisTemplate.opsForValue().multiGet(viewCountKeys);
         List<String> commentCounts = redisTemplate.opsForValue().multiGet(commentCountKeys);
         List<String> likeCounts = redisTemplate.opsForValue().multiGet(likeCountKeys);
 
-        /// 매번 반복
+        /// 순서대로 매핑해서 저장하기
         for (int i = 0; i < postList.size(); i++) {
             Post post = postList.get(i);
 
-            // Redis에서 가져온 값
-            String redisViewCount = viewCounts.get(i);
-            String redisCommentCount = commentCounts.get(i);
-            String redisLikeCount = likeCounts.get(i);
+            String redisViewCount = viewCounts != null ? viewCounts.get(i) : null;
+            String redisCommentCount = commentCounts != null ? commentCounts.get(i) : null;
+            String redisLikeCount = likeCounts != null ? likeCounts.get(i) : null;
 
-            // Redis에 값이 없으면 DB의 PostStat 값 사용
-            Long finalViewCount = (redisViewCount != null) ? Long.parseLong(redisViewCount) : post.getPostStat().getViewCount();
-            Long finalCommentCount = (redisCommentCount != null) ? Long.parseLong(redisCommentCount) : post.getPostStat().getCommentCount();
-            Long finalLikeCount = (redisLikeCount != null) ? Long.parseLong(redisLikeCount) : post.getPostStat().getLikeCount();
+            /// 수정할 값이 전부 없으면 안한다.
+            if (redisViewCount != null || redisCommentCount != null || redisLikeCount != null) {
 
-            /// 추가
-            post.getPostStat().updateStat(finalCommentCount, finalLikeCount, finalViewCount);
+                /// 있으면 Redis, 없으면 DB 값으로 수정
+                long viewCount = (redisViewCount != null) ? Long.parseLong(redisViewCount) : post.getPostStat().getViewCount();
+                long commentCount = (redisCommentCount != null) ? Long.parseLong(redisCommentCount) : post.getPostStat().getCommentCount();
+                long likeCount = (redisLikeCount != null) ? Long.parseLong(redisLikeCount) : post.getPostStat().getLikeCount();
+
+                /// 전체 값 수정하고 저장하기
+                post.getPostStat().updateStat(commentCount, likeCount, viewCount);
+                repository.save(post);
+            }
         }
-
+        return postPage;
     }
-
 }
+

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -28,25 +28,6 @@ public class ImageService implements ImageUseCase {
     /// 의존성
     private final UserRepository userRepository;
 
-    /// 한 장의 이미지 처리
-    @Override
-    @Transactional
-    public ImageResponse upload(ImageRequest req, Long userId) throws IOException {
-
-        /// 요청한 유저
-        User user = loadUser(userId);
-
-        /// 클라우드 요청
-        ImageResponse presignedURL = cloudService.getUploadPresignedURL(req.file());
-
-        /// 객체 저장
-        Image image = Image.of(user, req.file(), presignedURL.preSignedUrl());
-        repository.save(image);
-
-        /// 리턴
-        return presignedURL;
-    }
-
 
     /// 여러개의 이미지 처리
     @Override
@@ -58,7 +39,7 @@ public class ImageService implements ImageUseCase {
 
         /// 요청한 이미지 목록 추출
         List<String> reqImages = req.stream()
-                .map(ImageRequest::file)
+                .map(ImageRequest::imageUrl)
                 .toList();
 
         /// 클라우드 요청
@@ -81,10 +62,10 @@ public class ImageService implements ImageUseCase {
     public ImageResponse uploadTemporaryImage(ImageRequest req) throws IOException {
 
         /// 클라우드 요청
-        ImageResponse presignedURL = cloudService.getUploadPresignedURL(req.file());
+        ImageResponse presignedURL = cloudService.getUploadPresignedURL(req.imageUrl());
 
         /// 객체 저장
-        Image image = Image.temporaryOf(req.file(), presignedURL.preSignedUrl());
+        Image image = Image.temporaryOf(req.imageUrl(), presignedURL.preSignedUrl());
         repository.save(image);
 
         /// 리턴

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
@@ -9,9 +9,6 @@ import java.util.List;
 
 public interface ImageUseCase {
 
-    /// 사진 저장하기
-    ImageResponse upload(ImageRequest req, Long userId) throws IOException;
-
     /// 여러 사진 저장하기
     List<ImageResponse> upload(List<ImageRequest> req, Long userId) throws IOException;
 

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/dto/ImageRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "[요청][이미지] 이미지 업로드 Request", description = "이미지 업로드를 위한 DTO입니다.")
 public record ImageRequest(
-        @Schema(description = "이미지 파일(base64 인코딩)", example = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgA...")
-        String file
+        @Schema(description = "이미지 파일 주소", example = "https://example.com")
+        String imageUrl
 ) {
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -1,6 +1,7 @@
 package bootcamp.kakao.community.platform.posts.category.application;
 
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryResponse;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 import bootcamp.kakao.community.platform.posts.category.domain.repository.CategoryRepository;
 import bootcamp.kakao.community.platform.user.application.UserUseCase;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -66,6 +68,17 @@ public class CategoryService implements CategoryUseCase{
 
         /// 바로 삭제
         repository.delete(category);
+    }
+
+    /// 루트 카테고리 목록 조회하기
+    @Override
+    public List<CategoryResponse> readRootCategories() {
+
+        /// 카테고리 목록 조회
+        List<Category> categories = repository.findByParentNull();
+
+        /// 리턴
+        return CategoryResponse.from(categories);
     }
 
     // =================

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryUseCase.java
@@ -1,7 +1,9 @@
 package bootcamp.kakao.community.platform.posts.category.application;
 
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryResponse;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
+import java.util.List;
 
 public interface CategoryUseCase{
 
@@ -10,6 +12,9 @@ public interface CategoryUseCase{
 
     /// 카테고리 삭제하기 (운영자만 가능)
     void deleteCategory(Long id, Long userId);
+
+    /// 게시글 목록 조회
+    List<CategoryResponse> readRootCategories();
 
     /// 외부 로직
     Category loadCategory(Long id);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/dto/CategoryResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/dto/CategoryResponse.java
@@ -1,4 +1,31 @@
 package bootcamp.kakao.community.platform.posts.category.application.dto;
 
-public record CategoryResponse() {
+import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
+import lombok.Builder;
+import java.util.List;
+
+/// 카테고리 응답
+@Builder
+public record CategoryResponse(
+        Long id,
+        Long parentId,
+        String name
+) {
+
+    /// 정적 팩토리 메서드
+    public static CategoryResponse from(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .parentId(category.getParent() == null ? null : category.getParent().getId())
+                .name(category.getName())
+                .build();
+    }
+
+    /// 정적 팩토리 메서드
+    public static List<CategoryResponse> from(List<Category> categories) {
+        return categories.stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/domain/repository/CategoryRepository.java
@@ -2,6 +2,12 @@ package bootcamp.kakao.community.platform.posts.category.domain.repository;
 
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("SELECT c FROM Category c WHERE c.parent.id IS NULL")
+    List<Category> findByParentNull();
+
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/CategoryApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/CategoryApi.java
@@ -3,12 +3,14 @@ package bootcamp.kakao.community.platform.posts.category.presentation;
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.platform.posts.category.application.CategoryUseCase;
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryResponse;
 import bootcamp.kakao.community.platform.posts.category.presentation.swaager.CategoryApiSpec;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/category")
@@ -29,6 +31,18 @@ public class CategoryApi implements CategoryApiSpec {
         /// 리턴
         return ApiResponse.created();
     }
+
+    /// 카테고리 목록 조회
+    @GetMapping()
+    public ApiResponse<List<CategoryResponse>> list() {
+
+        /// 서비스
+        List<CategoryResponse> responses = service.readRootCategories();
+
+        /// 응답
+        return ApiResponse.ok(responses);
+    }
+
 
     /// 카테고리 삭제
     @DeleteMapping()

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/swaager/CategoryApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/presentation/swaager/CategoryApiSpec.java
@@ -2,6 +2,7 @@ package bootcamp.kakao.community.platform.posts.category.presentation.swaager;
 
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
+import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryResponse;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +10,8 @@ import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "카테고리 API", description = "카테고리 생성/조회/삭제하는 API 입니다.")
 public interface CategoryApiSpec {
@@ -20,6 +23,13 @@ public interface CategoryApiSpec {
     )
     ApiResponse<Void> create(@RequestBody @Valid CategoryRequest request,
                              @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+    /// 카테고리 목록 조회
+    @Operation(
+            summary = "카테고리 목록 조회 API",
+            description = "기본 카테고리를 조회하는 API 입니다."
+    )
+    ApiResponse<List<CategoryResponse>> list();
 
 
     /// 카테고리 삭제

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
@@ -2,6 +2,7 @@ package bootcamp.kakao.community.platform.posts.comment.application;
 
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
+import bootcamp.kakao.community.common.util.KeyUtil;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentListResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentRequest;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentUpdateRequest;
@@ -14,6 +15,7 @@ import bootcamp.kakao.community.platform.user.application.UserUseCase;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,9 @@ public class CommentService implements CommentUseCase{
     private final CommentRepository repository;
     private final PostQueryUseCase postService;
     private final UserUseCase userService;
+
+    /// 레디스 정의
+    private final StringRedisTemplate redisTemplate;
 
     /// 댓글 생성
     @Override
@@ -47,6 +52,10 @@ public class CommentService implements CommentUseCase{
         /// 객체 생성 및 저장
         var reqComment = Comment.of(post, user, parent, request.content());
         repository.save(reqComment);
+
+        /// 레디스에 값 1개 추가
+        String postViewKey = KeyUtil.getPostComment(post.getId());
+        redisTemplate.opsForValue().increment(postViewKey, 1L);
     }
 
     /**
@@ -117,6 +126,10 @@ public class CommentService implements CommentUseCase{
 
         /// 삭제
         comment.delete();
+
+        /// 레디스에 값 1개 삭제
+        String postViewKey = KeyUtil.getPostComment(comment.getPost().getId());
+        redisTemplate.opsForValue().decrement(postViewKey, 1L);
 
     }
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
@@ -17,10 +17,12 @@ import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -41,6 +43,8 @@ public class PostQueryService implements PostQueryUseCase{
     private final PostLikeUseCase likeUseCase;
 
     /// 게시글 목록 조회
+    // PostQueryService.java
+
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<PostListResponse> getPosts(SliceRequest req, Long categoryId) {
@@ -48,12 +52,53 @@ public class PostQueryService implements PostQueryUseCase{
         /// 카테고리 예외처리
         Category category = loadCategory(categoryId);
 
-        /// 요청에 따라서 목록 조회
+        /// DB에서 게시글 목록 조회
         Slice<Post> posts = repository.findPostsByCursor(req, category.getName(), false);
+        List<Post> postList = posts.getContent();
 
-        /// DTO 변화
-        Slice<PostListResponse> response = PostListResponse.from(posts);
-        return SliceResponse.from(response);
+        /// Redis에서 한번에 조회할 키 목록 생성
+        List<String> viewCountKeys = postList.stream()
+                .map(p -> KeyUtil.getPostView(p.getId()))
+                .toList();
+
+        List<String> commentCountKeys = postList.stream()
+                .map(p -> KeyUtil.getPostComment(p.getId()))
+                .toList();
+
+        List<String> likeCountKeys = postList.stream()
+                .map(p -> KeyUtil.getPostLike(p.getId()))
+                .toList();
+
+        /// Redis에 multiGet 요청으로 데이터 한번에 가져오기
+        List<String> viewCounts = redisTemplate.opsForValue().multiGet(viewCountKeys);
+        List<String> commentCounts = redisTemplate.opsForValue().multiGet(commentCountKeys);
+        List<String> likeCounts = redisTemplate.opsForValue().multiGet(likeCountKeys);
+
+        /// Post 목록을 순회하며 PostListResponse DTO 생성
+        List<PostListResponse> responses = new ArrayList<>();
+
+        for (int i = 0; i < postList.size(); i++) {
+            Post post = postList.get(i);
+
+            // Redis에서 가져온 값
+            String redisViewCount = viewCounts.get(i);
+            String redisCommentCount = commentCounts.get(i);
+            String redisLikeCount = likeCounts.get(i);
+
+            // Redis에 값이 없으면 DB의 PostStat 값 사용
+            Long finalViewCount = (redisViewCount != null) ? Long.parseLong(redisViewCount) : post.getPostStat().getViewCount();
+            Long finalCommentCount = (redisCommentCount != null) ? Long.parseLong(redisCommentCount) : post.getPostStat().getCommentCount();
+            Long finalLikeCount = (redisLikeCount != null) ? Long.parseLong(redisLikeCount) : post.getPostStat().getLikeCount();
+
+            /// 추가
+            responses.add(
+                    PostListResponse.from(post, finalViewCount, finalCommentCount, finalLikeCount)
+            );
+        }
+
+        /// 리턴
+        Slice<PostListResponse> responseSlice = new SliceImpl<>(responses, posts.getPageable(), posts.hasNext());
+        return SliceResponse.from(responseSlice);
     }
 
     /// 인기 게시글 목록 조회

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
@@ -75,19 +75,10 @@ public class PostQueryService implements PostQueryUseCase{
         /// 게시글 이미지 조회하기
         List<PostImage> images = postImageService.loadPostImages(post);
 
-        /// 조회수 증가시키기 및 가져오기
-        String postViewKey = KeyUtil.getPostView(post.getId());
-        Long viewCount = redisTemplate.opsForValue().increment(postViewKey, 1L);
-
-        /// 댓글 수, 레디스 조회하고, 없으면 DB 조회
-        String postCommentKey = KeyUtil.getPostComment(post.getId());
-        String commentStr = redisTemplate.opsForValue().get(postCommentKey);
-        Long commentCount = (commentStr != null) ? Long.parseLong(commentStr) : post.getPostStat().getCommentCount();
-
-        /// 좋아요 수
-        String postLikeKey = KeyUtil.getPostLike(post.getId());
-        String likeStr = redisTemplate.opsForValue().get(postLikeKey);
-        Long likeCount = (likeStr != null) ? Long.parseLong(likeStr) : post.getPostStat().getLikeCount();
+        /// 조회수, 댓글수,좋아요수 가져오기
+        Long viewCount = getViewCount(post);
+        Long commentCount = getCommentCount(post);
+        Long likeCount = getLikeCount(post);
 
         /// 비회원이 조회했다면
         if (userId == null) {
@@ -125,6 +116,106 @@ public class PostQueryService implements PostQueryUseCase{
 
     private Category loadCategory(Long categoryId) {
         return categoryService.loadCategory(categoryId);
+    }
+
+    /// 조회 수 가져오기
+    private Long getViewCount(Post post) {
+
+        /// 레디스 키 조회
+        String postViewKey = KeyUtil.getPostView(post.getId());
+        Long value;
+
+        try {
+            /// Redis 값 조회
+            String redisValue = redisTemplate.opsForValue().get(postViewKey);
+
+            if (redisValue != null) {
+                /// Redis 값 존재 -> +1 증가
+                value = Long.parseLong(redisValue) + 1L;
+            } else {
+                /// Redis 값 없음 -> DB 값 기반 초기화
+                value = post.getPostStat().getViewCount() + 1L;
+            }
+
+            /// Redis 업데이트
+            redisTemplate.opsForValue().set(postViewKey, String.valueOf(value));
+
+        } catch (Exception e) {
+            /// 예외 발생 시 DB 조회 및 저장
+            value = post.getPostStat().getViewCount() + 1L;
+
+            /// 저장
+            post.getPostStat().updateViewCount(value);
+            repository.save(post);
+        }
+
+        return value;
+    }
+
+    /// 댓글 수 가져오기
+    private Long getCommentCount(Post post) {
+
+        /// 레디스 키 조회
+        String postCommentKey = KeyUtil.getPostComment(post.getId());
+        Long value;
+
+        try {
+            /// Redis 값 조회
+            String redisValue = redisTemplate.opsForValue().get(postCommentKey);
+
+            if (redisValue != null) {
+                /// Redis 값 존재 -> +1 증가
+                value = Long.parseLong(redisValue);
+            } else {
+                /// Redis 값 없음 -> DB 값 기반 초기화
+                value = post.getPostStat().getCommentCount();
+            }
+
+            /// Redis 업데이트
+            log.info("레디스 업데이트");
+            redisTemplate.opsForValue().set(postCommentKey, String.valueOf(value));
+
+        } catch (Exception e) {
+            /// 예외 발생 시 DB 조회
+            log.info("DB 업데이트");
+            value = post.getPostStat().getCommentCount();
+        }
+
+        return value;
+
+
+    }
+
+    /// 좋아요 수 가져오기
+    private Long getLikeCount(Post post) {
+
+        /// 레디스 키 조회
+        String postLikeKey = KeyUtil.getPostLike(post.getId());
+        Long value;
+
+        try {
+            /// Redis 값 조회
+            String redisValue = redisTemplate.opsForValue().get(postLikeKey);
+
+            if (redisValue != null) {
+                /// Redis 값 존재 -> +1 증가
+                value = Long.parseLong(redisValue);
+            } else {
+                /// Redis 값 없음 -> DB 값 기반 초기화
+                value = post.getPostStat().getLikeCount();
+            }
+
+            /// Redis 업데이트
+            redisTemplate.opsForValue().set(postLikeKey, String.valueOf(value));
+
+        } catch (Exception e) {
+            /// 예외 발생 시 DB 조회
+            value = post.getPostStat().getLikeCount();
+        }
+
+        return value;
+
+
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
@@ -43,8 +43,6 @@ public class PostQueryService implements PostQueryUseCase{
     private final PostLikeUseCase likeUseCase;
 
     /// 게시글 목록 조회
-    // PostQueryService.java
-
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<PostListResponse> getPosts(SliceRequest req, Long categoryId) {
@@ -74,18 +72,18 @@ public class PostQueryService implements PostQueryUseCase{
         List<String> commentCounts = redisTemplate.opsForValue().multiGet(commentCountKeys);
         List<String> likeCounts = redisTemplate.opsForValue().multiGet(likeCountKeys);
 
-        /// Post 목록을 순회하며 PostListResponse DTO 생성
+        /// Post 목록을 순회하며 PostListResponse 생성
         List<PostListResponse> responses = new ArrayList<>();
 
         for (int i = 0; i < postList.size(); i++) {
             Post post = postList.get(i);
 
-            // Redis에서 가져온 값
+            /// Redis에서 가져온 값
             String redisViewCount = viewCounts.get(i);
             String redisCommentCount = commentCounts.get(i);
             String redisLikeCount = likeCounts.get(i);
 
-            // Redis에 값이 없으면 DB의 PostStat 값 사용
+            /// Redis에 값이 없으면 DB의 PostStat 값 사용
             Long finalViewCount = (redisViewCount != null) ? Long.parseLong(redisViewCount) : post.getPostStat().getViewCount();
             Long finalCommentCount = (redisCommentCount != null) ? Long.parseLong(redisCommentCount) : post.getPostStat().getCommentCount();
             Long finalLikeCount = (redisLikeCount != null) ? Long.parseLong(redisLikeCount) : post.getPostStat().getLikeCount();

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
@@ -15,29 +15,29 @@ import bootcamp.kakao.community.platform.posts.post_likes.application.PostLikeUs
 import bootcamp.kakao.community.platform.user.application.UserUseCase;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostQueryService implements PostQueryUseCase{
 
     private final PostRepository repository;
-    private final RedisTemplate<String, Object> redisTemplate;
 
-    /// 의존성
+    /// 레디스 정의
+    private final StringRedisTemplate redisTemplate;
+
+    /// 외부 의존성
     private final UserUseCase userService;
     private final CategoryUseCase categoryService;
-
-    /// 이미지
     private final PostImageUseCase postImageService;
-
-    /// 좋아요 여부 파악
     private final PostLikeUseCase likeUseCase;
 
     /// 게시글 목록 조회
@@ -66,7 +66,7 @@ public class PostQueryService implements PostQueryUseCase{
     /// 게시글 상세 조회
     /// 조회수가 상승해야한다.
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public PostDetailResponse getPost(Long postId, Long userId) {
 
         /// 게시글 DB 조회
@@ -75,21 +75,25 @@ public class PostQueryService implements PostQueryUseCase{
         /// 게시글 이미지 조회하기
         List<PostImage> images = postImageService.loadPostImages(post);
 
-        /// 조회했기에, 레디스에서 조회수 증가시키기
-        String redisKey = KeyUtil.getPostView(post.getId());
-        redisTemplate.opsForValue().increment(redisKey, 1);
+        /// 조회수 증가시키기 및 가져오기
+        String postViewKey = KeyUtil.getPostView(post.getId());
+        Long viewCount = redisTemplate.opsForValue().increment(postViewKey, 1L);
 
-        /// 레디스에서 조회 수, 댓글 수,좋아요 수를 가져와야한다.
-        // TODO! 레디스에서 값 가져오기
+        /// 댓글 수
+        String postCommentKey = KeyUtil.getPostComment(post.getId());
+        String commentStr = redisTemplate.opsForValue().get(postCommentKey);
+        Long commentCount = (commentStr != null) ? Long.parseLong(commentStr) : 0L;
+
+        /// 좋아요 수
+        String postLikeKey = KeyUtil.getPostLike(post.getId());
+        String likeStr = redisTemplate.opsForValue().get(postLikeKey);
+        Long likeCount = (likeStr != null) ? Long.parseLong(likeStr) : 0L;
 
         /// 비회원이 조회했다면
         if (userId == null) {
-
             /// 게시글의 정보만 전달하면 된다.
-            return PostDetailResponse.from(post, images);
-
+            return PostDetailResponse.from(post, images, viewCount, commentCount, likeCount);
         } else {
-
             /// 회원이 조회했다면,
             User user = loadUser(userId);
 
@@ -101,7 +105,7 @@ public class PostQueryService implements PostQueryUseCase{
             boolean editable = post.getUser().getId().equals(user.getId());
 
             /// 응답
-            return PostDetailResponse.from(post, images, liked, editable);
+            return PostDetailResponse.from(post, images, viewCount, commentCount, likeCount, liked, editable);
         }
     }
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
@@ -66,7 +66,7 @@ public class PostQueryService implements PostQueryUseCase{
     /// 게시글 상세 조회
     /// 조회수가 상승해야한다.
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public PostDetailResponse getPost(Long postId, Long userId) {
 
         /// 게시글 DB 조회
@@ -79,15 +79,15 @@ public class PostQueryService implements PostQueryUseCase{
         String postViewKey = KeyUtil.getPostView(post.getId());
         Long viewCount = redisTemplate.opsForValue().increment(postViewKey, 1L);
 
-        /// 댓글 수
+        /// 댓글 수, 레디스 조회하고, 없으면 DB 조회
         String postCommentKey = KeyUtil.getPostComment(post.getId());
         String commentStr = redisTemplate.opsForValue().get(postCommentKey);
-        Long commentCount = (commentStr != null) ? Long.parseLong(commentStr) : 0L;
+        Long commentCount = (commentStr != null) ? Long.parseLong(commentStr) : post.getPostStat().getCommentCount();
 
         /// 좋아요 수
         String postLikeKey = KeyUtil.getPostLike(post.getId());
         String likeStr = redisTemplate.opsForValue().get(postLikeKey);
-        Long likeCount = (likeStr != null) ? Long.parseLong(likeStr) : 0L;
+        Long likeCount = (likeStr != null) ? Long.parseLong(likeStr) : post.getPostStat().getLikeCount();
 
         /// 비회원이 조회했다면
         if (userId == null) {

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostDetailResponse.java
@@ -29,13 +29,13 @@ public record PostDetailResponse(
         String content,
 
         @Schema(description = "좋아요 수", example = "53")
-        int likeCount,
+        long likeCount,
 
         @Schema(description = "조회수", example = "1201")
-        int viewCount,
+        long viewCount,
 
         @Schema(description = "댓글수", example = "37")
-        int commentCount,
+        long commentCount,
 
         @Schema(description = "이미지 목록", example = "[{\"thumbnailUrl\": \"https://sample.com/image1.png\"}]")
         List<PostImageResponse> image,
@@ -54,8 +54,7 @@ public record PostDetailResponse(
 ) {
 
     /// (비회원용) 정적 팩토리 메서드
-    public static PostDetailResponse from(Post post, List<PostImage> imageList) {
-
+    public static PostDetailResponse from(Post post, List<PostImage> imageList, Long viewCount, Long commentCount, Long likeCount) {
         /// 정보 조회
         var stat = post.getPostStat();
 
@@ -65,9 +64,9 @@ public record PostDetailResponse(
                 .category(post.getCategory().getName())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .likeCount(stat.getLikeCount())
-                .viewCount(stat.getViewCount())
-                .commentCount(stat.getCommentCount())
+                .likeCount(likeCount == null ? 0 : likeCount)
+                .viewCount(viewCount == null ? 0 : viewCount)
+                .commentCount(commentCount == null ? 0 : commentCount)
                 .image(PostImageResponse.from(imageList))
                 .liked(false)
                 .editable(false)
@@ -77,19 +76,15 @@ public record PostDetailResponse(
     }
 
     /// (회원용) 정적 팩토리 메서드
-    public static PostDetailResponse from(Post post, List<PostImage> imageList, boolean liked, boolean editable) {
-
-        /// 정보 조회
-        var stat = post.getPostStat();
-
+    public static PostDetailResponse from(Post post, List<PostImage> imageList, Long viewCount, Long commentCount, Long likeCount, boolean liked, boolean editable) {
         return PostDetailResponse.builder()
                 .author(UserResponse.from(post.getUser()))
                 .category(post.getCategory().getName())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .likeCount(stat.getLikeCount())
-                .viewCount(stat.getViewCount())
-                .commentCount(stat.getCommentCount())
+                .likeCount(likeCount == null ? 0 : likeCount)
+                .viewCount(viewCount == null ? 0 : viewCount)
+                .commentCount(commentCount == null ? 0 : commentCount)
                 .image(PostImageResponse.from(imageList))
                 .liked(liked)
                 .editable(editable)
@@ -97,7 +92,4 @@ public record PostDetailResponse(
                 .updatedAt(post.getModifiedDate().toString())
                 .build();
     }
-
-
-
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
@@ -34,10 +34,10 @@ public record PostListResponse(
         String content,
 
         @Schema(description = "조회수", example = "102")
-        int viewCount,
+        long viewCount,
 
         @Schema(description = "댓글수", example = "18")
-        int commentCount,
+        long commentCount,
 
         @Schema(description = "작성일시", example = "2023-10-02T14:30:00")
         String createdAt

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostListResponse.java
@@ -39,6 +39,9 @@ public record PostListResponse(
         @Schema(description = "댓글수", example = "18")
         long commentCount,
 
+        @Schema(description = "좋아요수", example = "18")
+        long likeCount,
+
         @Schema(description = "작성일시", example = "2023-10-02T14:30:00")
         String createdAt
 
@@ -58,6 +61,24 @@ public record PostListResponse(
                 .content(post.getContent())
                 .viewCount(stat.getViewCount())
                 .commentCount(stat.getCommentCount())
+                .likeCount(stat.getLikeCount())
+                .createdAt(post.getCreatedDate().toString())
+                .build();
+    }
+
+    /// 정적 팩토리 메서드
+    public static PostListResponse from(Post post, Long viewCount, Long commentCount, Long likeCount) {
+
+        return PostListResponse.builder()
+                .id(post.getId())
+                .user(UserResponse.from(post.getUser()))
+                .category(post.getCategory().getName())
+                .thumbnailUrl(post.getThumbnailUrl())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .viewCount(viewCount)
+                .commentCount(commentCount)
+                .likeCount(likeCount)
                 .createdAt(post.getCreatedDate().toString())
                 .build();
     }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/PostStat.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/PostStat.java
@@ -12,19 +12,24 @@ import lombok.Getter;
 public class PostStat {
 
     @Column(nullable = false)
-    private int viewCount;
+    private long viewCount;
 
     @Column(nullable = false)
-    private int commentCount;
+    private long commentCount;
 
     @Column(nullable = false)
-    private int likeCount;
+    private long likeCount;
 
     /// 기본 값으로 생성자
     protected PostStat() {
         this.viewCount = 0;
         this.commentCount = 0;
         this.likeCount = 0;
+    }
+
+    ///  비즈니스 로직
+    public void updateViewCount(long viewCount) {
+        this.viewCount = viewCount;
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/PostStat.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/domain/entity/PostStat.java
@@ -27,8 +27,16 @@ public class PostStat {
         this.likeCount = 0;
     }
 
-    ///  비즈니스 로직
+    /// 비즈니스 로직
+    /// 조회수 수정
     public void updateViewCount(long viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    /// 전부 수정
+    public void updateStat(long commentCount, long likeCount, long viewCount) {
+        this.commentCount = commentCount;
+        this.likeCount = likeCount;
         this.viewCount = viewCount;
     }
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeService.java
@@ -1,5 +1,6 @@
 package bootcamp.kakao.community.platform.posts.post_likes.application;
 
+import bootcamp.kakao.community.common.util.KeyUtil;
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
 import bootcamp.kakao.community.platform.posts.post_likes.application.dto.PostLikeRequest;
@@ -8,6 +9,7 @@ import bootcamp.kakao.community.platform.posts.post_likes.domain.repository.Post
 import bootcamp.kakao.community.platform.user.application.UserUseCase;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,10 @@ public class PostLikeService implements PostLikeUseCase {
     private final PostRepository postRepository;
     private final UserUseCase userService;
 
+    /// 레디스 의존성
+    private final StringRedisTemplate redisTemplate;
+
+    /// 좋아요 하기
     @Override
     @Transactional
     public void like(PostLikeRequest request, Long userId) {
@@ -40,8 +46,13 @@ public class PostLikeService implements PostLikeUseCase {
         PostLike reqLike = PostLike.of(user, post);
         repository.save(reqLike);
 
+        /// 레디스에서 값 추가
+        String postLikeKey = KeyUtil.getPostLike(post.getId());
+        redisTemplate.opsForValue().increment(postLikeKey, 1L);
+
     }
 
+    /// 좋아요 취소하기
     @Override
     @Transactional
     public void unlike(Long postId, Long userId) {
@@ -60,6 +71,10 @@ public class PostLikeService implements PostLikeUseCase {
 
         /// 삭제 처리 (바로 삭제)
         repository.delete(optionalPostLike.get());
+
+        /// 레디스에서 값 빼기
+        String postLikeKey = KeyUtil.getPostLike(post.getId());
+        redisTemplate.opsForValue().decrement(postLikeKey, 1L);
     }
 
     /**


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 레디스에서 게시글 조회 수, 댓글 수, 좋아요 수 조회 기능 추가
- CommentService, PostQueryService 등에서 레디스를 사용해 실시간 카운트 처리
- KeyUtil에서 키 생성 로직 확장(댓글, 좋아요 키 추가)
- PostDetailResponse에서 각 카운트 항목 타입을 long으로 수정
- 게시글 상세조회 시, 레디스에서 각각의 통계 값을 가져오고 응답에 반영
- 변수명 일부 수정 및 미사용 코드 삭제

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- Redis의 StringRedisTemplate을 적극적으로 활용하도록 변경
- 실시간 카운트 반영이 필요한 부분은 모두 레디스 연동 완료
- 통계 값이 없을 때 0으로 안전하게 처리

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="1403" height="397" alt="image" src="https://github.com/user-attachments/assets/fb36a810-c907-4808-ac83-8c15139a1100" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#20 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
