### PR TITLE
✨ feat : 전역 예외 처리 만들기

### DIFF
--- a/src/main/java/bootcamp/kakao/community/common/aop/NonNullUser.java
+++ b/src/main/java/bootcamp/kakao/community/common/aop/NonNullUser.java
@@ -1,0 +1,9 @@
+package bootcamp.kakao.community.common.aop;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface NonNullUser {
+}

--- a/src/main/java/bootcamp/kakao/community/common/aop/NonNullUserAspect.java
+++ b/src/main/java/bootcamp/kakao/community/common/aop/NonNullUserAspect.java
@@ -1,0 +1,38 @@
+package bootcamp.kakao.community.common.aop;
+
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class NonNullUserAspect {
+
+    /// 한번 더 체크하는 AOP
+    @Around("@annotation(bootcamp.kakao.community.common.aop.NonNullUser)")
+    public Object checkLogin(ProceedingJoinPoint pjp) throws Throwable {
+
+        /// 먼저 인증 객체가 있는지 체크
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        /// 미인증(=null), 익명 토큰, Principal 타입 불일치 케이스 모두 차단
+        if (auth == null ||
+                !auth.isAuthenticated() ||
+                auth instanceof AnonymousAuthenticationToken ||
+                !(auth.getPrincipal() instanceof CustomUserDetails)) {
+
+            /// 401 매핑
+            throw new CustomException(CommonErrorCode.UNAUTHORIZED);
+        }
+
+        return pjp.proceed();
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/config/AwsS3Config.java
+++ b/src/main/java/bootcamp/kakao/community/common/config/AwsS3Config.java
@@ -1,6 +1,6 @@
 package bootcamp.kakao.community.common.config;
 
-import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.ImageErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +30,7 @@ public class AwsS3Config {
     @Bean
     public S3Presigner s3Presigner() {
         if (accessKey == null || accessSecret == null || region == null) {
-            throw new IllegalStateException(ErrorCode.INTERNAL_S3_ERROR.getMessage());
+            throw new IllegalStateException(ImageErrorCode.INTERNAL_S3_ERROR.getMessage());
         }
 
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
@@ -46,7 +46,7 @@ public class AwsS3Config {
     @Bean
     public S3Client s3Client() {
         if (accessKey == null || accessSecret == null || region == null) {
-            throw new IllegalStateException(ErrorCode.INTERNAL_S3_ERROR.getMessage());
+            throw new IllegalStateException(ImageErrorCode.INTERNAL_S3_ERROR.getMessage());
         }
 
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);

--- a/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
@@ -5,10 +5,13 @@ import bootcamp.kakao.community.common.response.CustomException;
 import bootcamp.kakao.community.common.response.ErrorCode;
 import bootcamp.kakao.community.common.response.FieldErrorResponse;
 import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.security.jwt.filter.JwtAuthenticationException;
+import jakarta.validation.UnexpectedTypeException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -35,10 +38,33 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(e));
     }
 
+    /// JWT 관련 커스템 에러 처리
+    @ExceptionHandler(JwtAuthenticationException.class)
+    public ResponseEntity<ApiResponse<?>> handleAuthenticationException(JwtAuthenticationException e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
+
+        /// 에러 코드
+        ErrorCode errorCode = e.getErrorCode();
+
+        /// 기본 에러 코드로 응답 생성
+        CustomException exception = new CustomException(errorCode);
+        var response = ApiResponse.fail(exception);
+
+        /// 응답
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(response);
+    }
+
     /// @Valid 파라미터 에러 처리
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ApiResponse<CustomException> handleValidationExceptions(MethodArgumentNotValidException e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
 
         /// 파라미터용 예외 코드
         ErrorCode errorCode = CommonErrorCode.BAD_PARAMETER;
@@ -48,6 +74,8 @@ public class GlobalExceptionHandler {
                 .stream()
                 .map(error -> FieldErrorResponse.of(error.getField(), error.getDefaultMessage()))
                 .toList();
+
+        log.error("저기");
 
         CustomException exception = new CustomException(errorCode, errors);
 
@@ -61,7 +89,7 @@ public class GlobalExceptionHandler {
     public ApiResponse<?> handleRedisConnectionFailureException(RedisConnectionFailureException e) {
 
         /// 에러 이유 로그 찍기
-        log.error(e.getMessage(), e);
+        log.error(e.getMessage());
 
         /// 기본 에러 코드로 응답 생성
         ErrorCode errorCode = CommonErrorCode.INTERNAL_REDIS_SERVER_ERROR;
@@ -93,15 +121,51 @@ public class GlobalExceptionHandler {
     public ApiResponse<?> handleIllegalException(Exception e) {
 
         /// 에러 이유 로그 찍기
-        log.error(e.getMessage());
+        log.error(e.getMessage(), e);
 
         /// 기본 에러 코드로 응답 생성
         ErrorCode errorCode = CommonErrorCode.BAD_REQUEST;
         CustomException exception = new CustomException(errorCode);
 
+        log.error("여기");
+
+
         /// 응답
         return ApiResponse.fail(exception);
     }
+
+    /// JSON 값 에러 처리
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ApiResponse<?> handleJSONException(HttpMessageNotReadableException e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
+
+        /// 기본 에러 코드로 응답 생성
+        ErrorCode errorCode = CommonErrorCode.BAD_REQUEST_JSON;
+        CustomException exception = new CustomException(errorCode);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(UnexpectedTypeException.class)
+    public ApiResponse<?> handleJUnexpectedTypeException(UnexpectedTypeException e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
+
+        /// 기본 에러 코드로 응답 생성
+        ErrorCode errorCode = CommonErrorCode.BAD_REQUEST_INVALID_INPUT;
+        CustomException exception = new CustomException(errorCode);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+
 
     /// 최하위 에러 처리 (여기까지는 안오길 ...)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -109,7 +173,7 @@ public class GlobalExceptionHandler {
     public ApiResponse<?> handleException(Exception e) {
 
         /// 에러 이유 로그 찍기
-        log.error(e.getMessage());
+        log.error(e.getMessage(), e);
 
         /// 기본 에러 코드로 응답 생성
         ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;

--- a/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
@@ -5,7 +5,6 @@ import bootcamp.kakao.community.common.response.CustomException;
 import bootcamp.kakao.community.common.response.ErrorCode;
 import bootcamp.kakao.community.common.response.FieldErrorResponse;
 import bootcamp.kakao.community.common.response.code.CommonErrorCode;
-import bootcamp.kakao.community.security.jwt.filter.JwtAuthenticationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.HttpStatus;
@@ -34,23 +33,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ApiResponse.fail(e));
-    }
-
-    /// JWT 관련 커스템 에러 처리
-    @ExceptionHandler(JwtAuthenticationException.class)
-    public ResponseEntity<ApiResponse<?>> handleAuthenticationException(JwtAuthenticationException e) {
-
-        /// 에러 코드
-        ErrorCode errorCode = e.getErrorCode();
-
-        /// 기본 에러 코드로 응답 생성
-        CustomException exception = new CustomException(errorCode);
-        var response = ApiResponse.fail(exception);
-
-        /// 응답
-        return ResponseEntity
-                .status(errorCode.getHttpStatus())
-                .body(response);
     }
 
     /// @Valid 파라미터 에러 처리

--- a/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
@@ -116,6 +116,22 @@ public class GlobalExceptionHandler {
     }
 
     /// 값이 없는 내용 에러 처리
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NullPointerException.class)
+    public ApiResponse<?> handleNullPointerException(NullPointerException e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
+
+        /// 기본 에러 코드로 응답 생성
+        ErrorCode errorCode = CommonErrorCode.NULL_VALUE;
+        CustomException exception = new CustomException(errorCode);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+    /// 값이 없는 내용 에러 처리
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
     public ApiResponse<?> handleIllegalException(Exception e) {

--- a/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,142 @@
 package bootcamp.kakao.community.common.exception;
 
+import bootcamp.kakao.community.common.response.ApiResponse;
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.FieldErrorResponse;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.security.jwt.filter.JwtAuthenticationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /// CustomException 에러 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+
+        /// 에러 코드
+        ErrorCode errorCode = e.getErrorCode();
+
+        /// 응답
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.fail(e));
+    }
+
+    /// JWT 관련 커스템 에러 처리
+    @ExceptionHandler(JwtAuthenticationException.class)
+    public ResponseEntity<ApiResponse<?>> handleAuthenticationException(JwtAuthenticationException e) {
+
+        /// 에러 코드
+        ErrorCode errorCode = e.getErrorCode();
+
+        /// 기본 에러 코드로 응답 생성
+        CustomException exception = new CustomException(errorCode);
+        var response = ApiResponse.fail(exception);
+
+        /// 응답
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(response);
+    }
+
+    /// @Valid 파라미터 에러 처리
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<CustomException> handleValidationExceptions(MethodArgumentNotValidException e) {
+
+        /// 파라미터용 예외 코드
+        ErrorCode errorCode = CommonErrorCode.BAD_PARAMETER;
+
+        /// 기본 에러 코드로 응답 생성 및 파라미터 담기
+        List<FieldErrorResponse> errors = e.getBindingResult().getFieldErrors()
+                .stream()
+                .map(error -> FieldErrorResponse.of(error.getField(), error.getDefaultMessage()))
+                .toList();
+
+        CustomException exception = new CustomException(errorCode, errors);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+    /// 레디스 에러 처리 핸들러
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    @ExceptionHandler(RedisConnectionFailureException.class)
+    public ApiResponse<?> handleRedisConnectionFailureException(RedisConnectionFailureException e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage(), e);
+
+        /// 기본 에러 코드로 응답 생성
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_REDIS_SERVER_ERROR;
+        CustomException exception = new CustomException(errorCode);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+    /// 값이 없는 내용 에러 처리
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler({NoSuchElementException.class, NoResourceFoundException.class})
+    public ApiResponse<?> handleNoSuchException(Exception e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
+
+        /// 기본 에러 코드로 응답 생성
+        ErrorCode errorCode = CommonErrorCode.NOT_FOUND;
+        CustomException exception = new CustomException(errorCode);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+    /// 값이 없는 내용 에러 처리
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
+    public ApiResponse<?> handleIllegalException(Exception e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
+
+        /// 기본 에러 코드로 응답 생성
+        ErrorCode errorCode = CommonErrorCode.BAD_REQUEST;
+        CustomException exception = new CustomException(errorCode);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+    /// 최하위 에러 처리 (여기까지는 안오길 ...)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<?> handleException(Exception e) {
+
+        /// 에러 이유 로그 찍기
+        log.error(e.getMessage());
+
+        /// 기본 에러 코드로 응답 생성
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        CustomException exception = new CustomException(errorCode);
+
+        /// 응답
+        return ApiResponse.fail(exception);
+    }
+
+
+
 }

--- a/src/main/java/bootcamp/kakao/community/common/logging/HttpLogUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/logging/HttpLogUtil.java
@@ -1,0 +1,27 @@
+package bootcamp.kakao.community.common.logging;
+
+import bootcamp.kakao.community.common.util.HttpUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HttpLogUtil {
+
+    private final HttpUtil httpUtil;
+
+    /// HTTP 대한 로그를 찍는 것
+    public void logHttpRequest(HttpServletRequest httpServletRequest, String type) {
+
+        /// 헤더에서 요청 정보 가져오기
+        var clientInfo = httpUtil.getClientInfo(httpServletRequest);
+
+        /// 로그
+        log.info("{} : {}, [{}], {}, {}", type, clientInfo.ip(), clientInfo.httpMethod(), clientInfo.uri(), clientInfo.userName());
+
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/logging/LogFilter.java
+++ b/src/main/java/bootcamp/kakao/community/common/logging/LogFilter.java
@@ -1,0 +1,25 @@
+package bootcamp.kakao.community.common.logging;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class LogFilter extends OncePerRequestFilter {
+
+    private final HttpLogUtil logUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        /// 로그 찍고 넘기기
+        logUtil.logHttpRequest(request, LogType.HTTP.getLabel());
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/bootcamp/kakao/community/common/logging/LogType.java
+++ b/src/main/java/bootcamp/kakao/community/common/logging/LogType.java
@@ -1,0 +1,16 @@
+package bootcamp.kakao.community.common.logging;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum LogType {
+
+    HTTP("[HTTP 로그]"),
+    ERROR_401("[인증 에러]"),
+    ERROR_403("[인가 에러]");
+
+    private final String label;
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/CustomException.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/CustomException.java
@@ -1,7 +1,6 @@
 package bootcamp.kakao.community.common.response;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
@@ -12,12 +11,22 @@ import java.util.List;
  */
 
 @Getter
-@RequiredArgsConstructor
 public class CustomException extends RuntimeException{
 
     private final ErrorCode errorCode;
 
-    private final List<FieldErrorResponse> fieldErrorResponses;
+    private List<FieldErrorResponse> fieldErrorResponses;
 
+
+    /// 에러코드만 있는 경우
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    /// 에러코드와 필드에러가 같이 있는 경우
+    public CustomException(ErrorCode errorCode, List<FieldErrorResponse> fieldErrorResponses) {
+        this.errorCode = errorCode;
+        this.fieldErrorResponses = fieldErrorResponses;
+    }
 
 }

--- a/src/main/java/bootcamp/kakao/community/common/response/CustomException.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/CustomException.java
@@ -1,9 +1,11 @@
 package bootcamp.kakao.community.common.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
-
 
 /**
  * 응답을 하는 커스텀 예외 클래스입니다.
@@ -11,16 +13,17 @@ import java.util.List;
  */
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CustomException extends RuntimeException{
 
     private final ErrorCode errorCode;
-
-    private List<FieldErrorResponse> fieldErrorResponses;
+    private final List<FieldErrorResponse> fieldErrorResponses;
 
 
     /// 에러코드만 있는 경우
     public CustomException(ErrorCode errorCode) {
         this.errorCode = errorCode;
+        this.fieldErrorResponses = null;
     }
 
     /// 에러코드와 필드에러가 같이 있는 경우

--- a/src/main/java/bootcamp/kakao/community/common/response/ErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/ErrorCode.java
@@ -1,93 +1,13 @@
 package bootcamp.kakao.community.common.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-/**
- * 애플리케이션 전역에서 사용하는 에러 코드 Enum입니다.
- * 각 에러는 고유 코드, HTTP 상태, 메시지를 포함합니다.
- */
-@Getter
-@AllArgsConstructor
-public enum ErrorCode {
+public interface ErrorCode {
 
+    Integer getCode();
 
-    // ========================
-    // 0~1000 : 공통 및 보안 에러
-    // ========================
+    String getMessage();
 
-    // ========================
-    // 400 Bad Request
-    // ========================
-    BAD_REQUEST(400_000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    INVALID_INPUT(400_001, HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
-    NULL_VALUE(400_002, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
-
-    // ========================
-    // 401 Unauthorized
-    // ========================
-    ACCESS_TOKEN_EXPIRED(401_000, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
-    ACCESS_TOKEN_INVALID(401_001, HttpStatus.UNAUTHORIZED, "액세스 토큰이 유효하지 않습니다."),
-    ACCESS_TOKEN_UNSUPPORTED(401_002, HttpStatus.UNAUTHORIZED, "액세스 토큰이 지원하지 않는 형식입니다."),
-    ACCESS_TOKEN_MALFORMED(401_004, HttpStatus.UNAUTHORIZED, "액세스 토큰의 구조가 깨진 형식입니다."),
-    ACCESS_TOKEN_NOT_FOUND(401_002, HttpStatus.UNAUTHORIZED, "액세스 토큰이 존재하지 않습니다."),
-
-    REFRESH_TOKEN_EXPIRED(401_004, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 만료되었습니다."),
-    REFRESH_TOKEN_INVALID(401_005, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 유효하지 않은 토큰입니다."),
-    REFRESH_TOKEN_UNSUPPORTED(401_006, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 지원하지 않는 토큰 형식입니다."),
-
-
-    REFRESH_INVALID_LOGIN(401_007, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 없기에 재로그인이 필요합니다."),
-    TOKEN_NOT_FOUND_COOKIE(401_010, HttpStatus.UNAUTHORIZED, "쿠키에 리프레시 토큰이 존재하지 않습니다."),
-
-
-    // ========================
-    // 403 Forbidden
-    // ========================
-    FORBIDDEN(403_000, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
-    ACCESS_DENY(403_001, HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
-    UNAUTHORIZED_POST_ACCESS(403_002, HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다."),
-
-
-    // ========================
-    // 404 Not Found
-    // ========================
-    NOT_FOUND_END_POINT(404_000, HttpStatus.NOT_FOUND, "요청한 대상이 존재하지 않습니다."),
-    USER_NOT_FOUND(404_001, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    USER_NOT_FOUND_IN_COOKIE(404_002, HttpStatus.NOT_FOUND, "쿠키에서 사용자 정보를 찾을 수 없습니다."),
-    POST_NOT_FOUND(404_003, HttpStatus.NOT_FOUND, "요청한 게시글을 찾을 수 없습니다."),
-    POST_TYPE_NOT_FOUND(404_004, HttpStatus.NOT_FOUND, "게시글 타입을 찾을 수 없습니다."),
-    COMMENT_NOT_FOUND(404_005, HttpStatus.NOT_FOUND, "요청한 댓글을 찾을 수 없습니다."),
-
-    // ========================
-    // 409 Conflict
-    // ========================
-    DUPLICATE_EMAIL(409_001, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-
-
-    // ========================
-    // 500 Internal Server Error
-    // ========================
-    INTERNAL_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
-    INTERNAL_S3_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 설정이 잘못되었습니다. 속성을 확인하세요."),
-    INTERNAL_S3_URL_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 PreSignedURL 설정이 잘못되었습니다. 속성을 확인하세요."),
-    BAD_PARAMETER(999, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다.");
-
-
-    /**
-     * 에러 코드 (고유값)
-     */
-    private final Integer code;
-
-    /**
-     * HTTP 상태 코드
-     */
-    private final HttpStatus httpStatus;
-
-    /**
-     * 에러 메시지
-     */
-    private final String message;
+    HttpStatus getHttpStatus();
 
 }

--- a/src/main/java/bootcamp/kakao/community/common/response/code/CommonErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/CommonErrorCode.java
@@ -17,14 +17,15 @@ public enum CommonErrorCode implements ErrorCode {
     // 400 Bad Request
     // ========================
     BAD_REQUEST(400_000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    INVALID_INPUT(400_001, HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
-    NULL_VALUE(400_002, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
-    BAD_PARAMETER(400_003, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다."),
+    NULL_VALUE(400_001, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
+    BAD_PARAMETER(400_002, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다."),
+    BAD_REQUEST_JSON(400_003, HttpStatus.BAD_REQUEST, "JSON 파싱에 문제가 존재합니다."),
+    BAD_REQUEST_INVALID_INPUT(400_004, HttpStatus.BAD_REQUEST, "입력 값 검증조건이 올바르지 않습니다."),
 
     // ========================
     // 401 Unauthorized
     // ========================
-    UNAUTHORIZED(401_000, HttpStatus.UNAUTHORIZED, "인증 문제가 발생했습니다."),
+    UNAUTHORIZED(401_000, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
 
     // ========================
     // 403 Forbidden

--- a/src/main/java/bootcamp/kakao/community/common/response/code/CommonErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/CommonErrorCode.java
@@ -1,0 +1,66 @@
+package bootcamp.kakao.community.common.response.code;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 공통 예외처리 클래스입니다.
+ */
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+
+    // ========================
+    // 400 Bad Request
+    // ========================
+    BAD_REQUEST(400_000, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_INPUT(400_001, HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+    NULL_VALUE(400_002, HttpStatus.BAD_REQUEST, "Null 값이 들어왔습니다."),
+    BAD_PARAMETER(400_003, HttpStatus.BAD_REQUEST, "요청 파라미터에 문제가 존재합니다."),
+
+    // ========================
+    // 401 Unauthorized
+    // ========================
+    UNAUTHORIZED(401_000, HttpStatus.UNAUTHORIZED, "인증 문제가 발생했습니다."),
+
+    // ========================
+    // 403 Forbidden
+    // ========================
+    FORBIDDEN(403_000, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
+
+    // ========================
+    // 404 Not Found
+    // ========================
+    NOT_FOUND(404_000, HttpStatus.NOT_FOUND, "요청한 대상이 존재하지 않습니다."),
+
+
+    // ========================
+    // 409 Conflict
+    // ========================
+    CONFLICT(409_000, HttpStatus.CONFLICT, "중복된 항목이 존재합니다."),
+
+    // ========================
+    // 500 Internal Server Error
+    // ========================
+    INTERNAL_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+
+
+    /**
+     * 에러 코드 (고유값)
+     */
+    private final Integer code;
+
+    /**
+     * HTTP 상태 코드
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 에러 메시지
+     */
+    private final String message;
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/code/CommonErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/CommonErrorCode.java
@@ -45,7 +45,8 @@ public enum CommonErrorCode implements ErrorCode {
     // ========================
     // 500 Internal Server Error
     // ========================
-    INTERNAL_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_REDIS_SERVER_ERROR(500_000, HttpStatus.INTERNAL_SERVER_ERROR, "레디스 내부 오류입니다."),
+    INTERNAL_SERVER_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
 
 
     /**

--- a/src/main/java/bootcamp/kakao/community/common/response/code/ImageErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/ImageErrorCode.java
@@ -1,0 +1,57 @@
+package bootcamp.kakao.community.common.response.code;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 이미지 예외처리 클래스입니다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+
+    // ========================
+    // 400 Bad Request
+    // ========================
+
+    // ========================
+    // 401 Unauthorized
+    // ========================
+
+    // ========================
+    // 403 Forbidden
+    // ========================
+
+    // ========================
+    // 404 Not Found
+    // ========================
+
+    // ========================
+    // 409 Conflict
+    // ========================
+
+    // ========================
+    // 500 Internal Server Error
+    // ========================
+    INTERNAL_S3_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 설정이 잘못되었습니다. 속성을 확인하세요."),
+    INTERNAL_S3_URL_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 PreSignedURL 설정이 잘못되었습니다. 속성을 확인하세요.");
+
+
+
+    /**
+     * 에러 코드 (고유값)
+     */
+    private final Integer code;
+
+    /**
+     * HTTP 상태 코드
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 에러 메시지
+     */
+    private final String message;
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/code/ImageErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/ImageErrorCode.java
@@ -27,6 +27,7 @@ public enum ImageErrorCode implements ErrorCode {
     // ========================
     // 404 Not Found
     // ========================
+    NOT_FOUND_IMAGE(404_100, HttpStatus.NOT_FOUND, "해당 이미지가 존재하지 않습니다."),
 
     // ========================
     // 409 Conflict
@@ -35,8 +36,8 @@ public enum ImageErrorCode implements ErrorCode {
     // ========================
     // 500 Internal Server Error
     // ========================
-    INTERNAL_S3_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 설정이 잘못되었습니다. 속성을 확인하세요."),
-    INTERNAL_S3_URL_ERROR(500_001, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 PreSignedURL 설정이 잘못되었습니다. 속성을 확인하세요.");
+    INTERNAL_S3_ERROR(500_101, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 설정이 잘못되었습니다. 속성을 확인하세요."),
+    INTERNAL_S3_URL_ERROR(500_101, HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 PreSignedURL 설정이 잘못되었습니다. 속성을 확인하세요.");
 
 
 

--- a/src/main/java/bootcamp/kakao/community/common/response/code/PostErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/PostErrorCode.java
@@ -16,23 +16,26 @@ public enum PostErrorCode implements ErrorCode {
     // 400 Bad Request
     // ========================
     BAD_REQUEST_POST(400_200, HttpStatus.BAD_REQUEST, "게시글 요청 파라미터가 잘못되었습니다."),
-
+    BAD_REQUEST_POST_LIKES(400_201, HttpStatus.BAD_REQUEST, "좋아요를 누르지 않았기에 취소가 불가능합니다."),
     // ========================
     // 403 Forbidden
     // ========================
     FORBIDDEN_POST_EDIT(403_200, HttpStatus.FORBIDDEN, "해당 게시글을 수정/삭제할 권한이 없습니다."),
+    FORBIDDEN_COMMENT_EDIT(403_201,HttpStatus.FORBIDDEN, "해당 댓글을 수정/삭제할 댓글이 없습니다."),
+    FORBIDDEN_CATEGORY_CREATE(403_202, HttpStatus.FORBIDDEN, "운영자만 카테고리를 생성할 수 있습니다."),
+    FORBIDDEN_CATEGORY_EDIT(403_203, HttpStatus.FORBIDDEN, "운영자만 카테고리를 삭제할 수 있습니다."),
 
     // ========================
     // 404 Not Found
     // ========================
-    NOT_FOUND_POST(404_200, HttpStatus.NOT_FOUND, "요청한 게시글을 찾을 수 없습니다."),
-    NOT_FOUND_POST_TYPE(404_201, HttpStatus.NOT_FOUND, "게시글 타입을 찾을 수 없습니다."),
-    NOT_FOUND_COMMENT(404_202, HttpStatus.NOT_FOUND, "요청한 댓글을 찾을 수 없습니다.");
+    NOT_FOUND_POST(404_200, HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+    NOT_FOUND_COMMENT(404_202, HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+    NOT_FOUND_CATEGORY(404_204,HttpStatus.NOT_FOUND,"해당 카테고리를 찾을 수 없습니다.")
+    ;
 
     // ========================
     // 409 Conflict
     // ========================
-
 
 
     /**
@@ -49,4 +52,5 @@ public enum PostErrorCode implements ErrorCode {
      * 에러 메시지
      */
     private final String message;
+
 }

--- a/src/main/java/bootcamp/kakao/community/common/response/code/PostErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/PostErrorCode.java
@@ -1,0 +1,52 @@
+package bootcamp.kakao.community.common.response.code;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 게시글 예외처리 클래스입니다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+
+    // ========================
+    // 400 Bad Request
+    // ========================
+    BAD_REQUEST_POST(400_200, HttpStatus.BAD_REQUEST, "게시글 요청 파라미터가 잘못되었습니다."),
+
+    // ========================
+    // 403 Forbidden
+    // ========================
+    FORBIDDEN_POST_EDIT(403_200, HttpStatus.FORBIDDEN, "해당 게시글을 수정/삭제할 권한이 없습니다."),
+
+    // ========================
+    // 404 Not Found
+    // ========================
+    NOT_FOUND_POST(404_200, HttpStatus.NOT_FOUND, "요청한 게시글을 찾을 수 없습니다."),
+    NOT_FOUND_POST_TYPE(404_201, HttpStatus.NOT_FOUND, "게시글 타입을 찾을 수 없습니다."),
+    NOT_FOUND_COMMENT(404_202, HttpStatus.NOT_FOUND, "요청한 댓글을 찾을 수 없습니다.");
+
+    // ========================
+    // 409 Conflict
+    // ========================
+
+
+
+    /**
+     * 에러 코드 (고유값)
+     */
+    private final Integer code;
+
+    /**
+     * HTTP 상태 코드
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 에러 메시지
+     */
+    private final String message;
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/code/ReportErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/ReportErrorCode.java
@@ -15,6 +15,7 @@ public enum ReportErrorCode implements ErrorCode {
     // ========================
     // 400 Bad Request
     // ========================
+    BAD_REQUEST_REPORT_TYPE(400_300, HttpStatus.BAD_REQUEST, "신고 타입으로 잘못된 값을 입력했습니다."),
 
     // ========================
     // 401 Unauthorized

--- a/src/main/java/bootcamp/kakao/community/common/response/code/ReportErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/ReportErrorCode.java
@@ -1,0 +1,55 @@
+package bootcamp.kakao.community.common.response.code;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 신고 예외처리 클래스입니다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ReportErrorCode implements ErrorCode {
+
+    // ========================
+    // 400 Bad Request
+    // ========================
+
+    // ========================
+    // 401 Unauthorized
+    // ========================
+
+    // ========================
+    // 403 Forbidden
+    // ========================
+
+    // ========================
+    // 404 Not Found
+    // ========================
+
+    // ========================
+    // 409 Conflict
+    // ========================
+
+    // ========================
+    // 500 Internal Server Error
+    // ========================
+    ;
+
+
+    /**
+     * 에러 코드 (고유값)
+     */
+    private final Integer code;
+
+    /**
+     * HTTP 상태 코드
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 에러 메시지
+     */
+    private final String message;
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/code/SecurityErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/SecurityErrorCode.java
@@ -1,0 +1,67 @@
+package bootcamp.kakao.community.common.response.code;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 보안 예외처리 클래스입니다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum SecurityErrorCode implements ErrorCode {
+
+    // ========================
+    // 400 Bad Request
+    // ========================
+
+    // ========================
+    // 401 Unauthorized
+    // ========================
+    ACCESS_TOKEN_EXPIRED(401_000, HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
+    ACCESS_TOKEN_INVALID(401_001, HttpStatus.UNAUTHORIZED, "액세스 토큰이 유효하지 않습니다."),
+    ACCESS_TOKEN_UNSUPPORTED(401_002, HttpStatus.UNAUTHORIZED, "액세스 토큰이 지원하지 않는 형식입니다."),
+    ACCESS_TOKEN_MALFORMED(401_004, HttpStatus.UNAUTHORIZED, "액세스 토큰의 구조가 깨진 형식입니다."),
+    ACCESS_TOKEN_NOT_FOUND(401_002, HttpStatus.UNAUTHORIZED, "액세스 토큰이 존재하지 않습니다."),
+
+    REFRESH_TOKEN_EXPIRED(401_004, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 만료되었습니다."),
+    REFRESH_TOKEN_INVALID(401_005, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_UNSUPPORTED(401_006, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 지원하지 않는 토큰 형식입니다."),
+    REFRESH_INVALID_LOGIN(401_007, HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 없기에 재로그인이 필요합니다."),
+    TOKEN_NOT_FOUND_COOKIE(401_010, HttpStatus.UNAUTHORIZED, "쿠키에 리프레시 토큰이 존재하지 않습니다."),
+
+
+    // ========================
+    // 403 Forbidden
+    // ========================
+
+    FORBIDDEN(403_000, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
+    ACCESS_DENY(403_001, HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
+    UNAUTHORIZED_POST_ACCESS(403_002, HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다."),
+
+    // ========================
+    // 404 Not Found
+    // ========================
+    USER_NOT_FOUND_IN_COOKIE(404_002, HttpStatus.NOT_FOUND, "쿠키에서 사용자 정보를 찾을 수 없습니다.");
+
+    // ========================
+    // 500 Internal Server Error
+    // ========================
+
+
+    /**
+     * 에러 코드 (고유값)
+     */
+    private final Integer code;
+
+    /**
+     * HTTP 상태 코드
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 에러 메시지
+     */
+    private final String message;
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/code/SecurityErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/SecurityErrorCode.java
@@ -15,6 +15,7 @@ public enum SecurityErrorCode implements ErrorCode {
     // ========================
     // 400 Bad Request
     // ========================
+    BAD_REQUEST_LOGIN(400_000, HttpStatus.BAD_REQUEST, "로그인할 수 없습니다."),
 
     // ========================
     // 401 Unauthorized
@@ -35,7 +36,6 @@ public enum SecurityErrorCode implements ErrorCode {
     // ========================
     // 403 Forbidden
     // ========================
-
     FORBIDDEN(403_000, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
     ACCESS_DENY(403_001, HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
     UNAUTHORIZED_POST_ACCESS(403_002, HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다."),
@@ -43,7 +43,9 @@ public enum SecurityErrorCode implements ErrorCode {
     // ========================
     // 404 Not Found
     // ========================
-    USER_NOT_FOUND_IN_COOKIE(404_002, HttpStatus.NOT_FOUND, "쿠키에서 사용자 정보를 찾을 수 없습니다.");
+    NOT_FOUND_EMAIL(404_400, HttpStatus.NOT_FOUND, "해당 이메일을 가진 유저가 없습니다"),
+    NOT_FOUND_ID(404_401, HttpStatus.NOT_FOUND, "해당 아이디을 가진 유저가 없습니다"),
+    USER_NOT_FOUND_IN_COOKIE(404_402, HttpStatus.NOT_FOUND, "쿠키에서 사용자 정보를 찾을 수 없습니다.");
 
     // ========================
     // 500 Internal Server Error

--- a/src/main/java/bootcamp/kakao/community/common/response/code/UserErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/UserErrorCode.java
@@ -1,0 +1,58 @@
+package bootcamp.kakao.community.common.response.code;
+
+import bootcamp.kakao.community.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 유저 예외처리 클래스입니다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    // ========================
+    // 400 Bad Request
+    // ========================
+
+    // ========================
+    // 401 Unauthorized
+    // ========================
+
+    // ========================
+    // 403 Forbidden
+    // ========================
+
+    // ========================
+    // 404 Not Found
+    // ========================
+    NOT_FOUND_USER(404_001, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // ========================
+    // 409 Conflict
+    // ========================
+    CONFLICT_DUPLICATE_NICKNAME(409_000, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+    CONFLICT_DUPLICATE_EMAIL(409_001, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다.");
+
+    // ========================
+    // 500 Internal Server Error
+    // ========================
+
+
+    /**
+     * 에러 코드 (고유값)
+     */
+    private final Integer code;
+
+    /**
+     * HTTP 상태 코드
+     */
+    private final HttpStatus httpStatus;
+
+    /**
+     * 에러 메시지
+     */
+    private final String message;
+
+}

--- a/src/main/java/bootcamp/kakao/community/common/response/code/UserErrorCode.java
+++ b/src/main/java/bootcamp/kakao/community/common/response/code/UserErrorCode.java
@@ -15,6 +15,8 @@ public enum UserErrorCode implements ErrorCode {
     // ========================
     // 400 Bad Request
     // ========================
+    BAD_REQUEST_EQUAL_PASSWORD(400_000, HttpStatus.BAD_REQUEST, "패스워드가 일치하지 않는 문제입니다."),
+    BAD_REQUEST_OLD_PASSWORD(400_001, HttpStatus.BAD_REQUEST, "기존 비밀번호와 일치하지 않습니다."),
 
     // ========================
     // 401 Unauthorized
@@ -27,7 +29,7 @@ public enum UserErrorCode implements ErrorCode {
     // ========================
     // 404 Not Found
     // ========================
-    NOT_FOUND_USER(404_001, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_USER(404_001, HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
 
     // ========================
     // 409 Conflict

--- a/src/main/java/bootcamp/kakao/community/common/util/HttpUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/util/HttpUtil.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import static bootcamp.kakao.community.common.util.KeyUtil.*;
 
@@ -63,6 +65,29 @@ public class HttpUtil {
     /// Header에서 어떤 디바이스인지 체크
     public String getDeviceType(HttpServletRequest httpServletRequest) {
         return httpServletRequest.getHeader("User-Agent");
+    }
+
+    /// 요청자의 정보를 헤더에서 조회하기 위한 함수
+    public HeaderInfo getClientInfo(HttpServletRequest request) {
+
+        /// IP
+        String ip = getClientIp(request);
+
+        /// 메서드
+        String httpMethod = request.getMethod();
+
+        /// 요청 주소
+        String uri = URLDecoder.decode(request.getRequestURI(), StandardCharsets.UTF_8);
+
+        /// 요청자
+        String username = request.getUserPrincipal() != null ? request.getUserPrincipal().getName() : "익명";
+
+        return new HeaderInfo(ip, httpMethod, uri, username);
+    }
+
+    /// 헤더의 값을 전달하기 위해서 레코드 클래스 생성
+    public record HeaderInfo(String ip, String httpMethod, String uri, String userName) {
+
     }
 
     // =================
@@ -130,7 +155,24 @@ public class HttpUtil {
 
         /// Bearer (띄어쓰기 포함 7글자) 빼고 가져오기
         return headerToken.substring(7);
+    }
 
+    /// 요청자의 실제 IP를 조회하기 위한 함수
+    private String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+
+        /// X-Forwarded-For이 있다면
+        if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+            // 여러 개라면 첫 번째 값이 클라이언트 IP
+            return ip.split(",")[0].trim();
+        }
+
+        /// X-Forwarded-For이 없다면
+        ip = request.getHeader("X-Real-IP");
+        if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+            return ip;
+        }
+        return request.getRemoteAddr();
     }
 }
 

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -1,5 +1,8 @@
 package bootcamp.kakao.community.platform.images.image.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.code.ImageErrorCode;
+import bootcamp.kakao.community.common.response.code.UserErrorCode;
 import bootcamp.kakao.community.platform.images.image.application.dto.ImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
 import bootcamp.kakao.community.platform.images.image.domain.entity.Image;
@@ -78,7 +81,7 @@ public class ImageService implements ImageUseCase {
     public Image getImage(String url) {
 
         return repository.findByUrl(url)
-                .orElseThrow(() -> new NoSuchElementException("해당 이미지가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ImageErrorCode.NOT_FOUND_IMAGE));
     }
 
     /// URL 목록 바탕으로 이미지 배열 객체 조회하기
@@ -106,7 +109,7 @@ public class ImageService implements ImageUseCase {
     @Transactional
     protected User loadUser(Long userId) {
         return userRepository.findByIdAndDeletedIsFalse(userId)
-                .orElseThrow(()-> new NoSuchElementException("해당 아이디를 가진 유저가 없습니다."));
+                .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND_USER));
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/external/S3Util.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/external/S3Util.java
@@ -1,6 +1,7 @@
 package bootcamp.kakao.community.platform.images.image.external;
 
-import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.common.response.code.ImageErrorCode;
 import bootcamp.kakao.community.common.util.ImageUtil;
 import bootcamp.kakao.community.platform.images.image.application.dto.ImageResponse;
 import lombok.RequiredArgsConstructor;
@@ -66,7 +67,7 @@ public class S3Util implements ImageCloudUseCase {
                     try {
                         return getUploadPresignedURL(file);
                     } catch (IOException e) {
-                        throw new IllegalStateException(ErrorCode.INTERNAL_S3_URL_ERROR.getMessage());
+                        throw new IllegalStateException(ImageErrorCode.INTERNAL_S3_URL_ERROR.getMessage());
                     }
                 })
                 .toList();

--- a/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/category/application/CategoryService.java
@@ -1,5 +1,8 @@
 package bootcamp.kakao.community.platform.posts.category.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.PostErrorCode;
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryRequest;
 import bootcamp.kakao.community.platform.posts.category.application.dto.CategoryResponse;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
@@ -36,13 +39,12 @@ public class CategoryService implements CategoryUseCase{
 
         /// 운영자가 일때만 가능
         if (!(user.getRole() == UserRole.ADMIN)) {
-            throw new IllegalStateException("운영자만 카테고리를 생성할 수 있습니다.");
+            throw new CustomException(PostErrorCode.FORBIDDEN_CATEGORY_CREATE);
         }
 
         /// 부모 값이 존재한다면,
         if (req.parentId() != null) {
-            parent = repository.findById(req.parentId())
-                    .orElseThrow(NoSuchElementException::new);
+            parent = loadCategory(req.parentId());
         }
         Category reqCategory = Category.of(parent, req.name());
 
@@ -63,7 +65,7 @@ public class CategoryService implements CategoryUseCase{
 
         /// 운영자가 일때만 가능
         if (!(user.getRole() == UserRole.ADMIN)) {
-            throw new IllegalStateException("운영자만 카테고리를 삭제할 수 있습니다.");
+            throw new CustomException(PostErrorCode.FORBIDDEN_CATEGORY_EDIT);
         }
 
         /// 바로 삭제
@@ -87,6 +89,6 @@ public class CategoryService implements CategoryUseCase{
     @Override
     public Category loadCategory(Long id) {
         return repository.findById(id)
-                .orElseThrow(NoSuchElementException::new);
+                .orElseThrow(() -> new CustomException(PostErrorCode.NOT_FOUND_CATEGORY));
     }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
@@ -96,14 +96,14 @@ public class CommentService implements CommentUseCase{
 
     @Override
     @Transactional
-    public void updateComment(CommentUpdateRequest request, Long userId) {
+    public void updateComment(Long id, CommentUpdateRequest request, Long userId) {
 
         /// 유저 예외처리
         User user = userService.loadUser(userId);
 
         /// 나의 댓글인 지 조회
         /// ID 존재 및 작성 여부를 한번에 파악
-        Comment comment = repository.findByUserAndId(user, request.id())
+        Comment comment = repository.findByUserAndId(user, id)
                 .orElseThrow(() -> new NoSuchElementException("해당 유저가 수정할 댓글이 없습니다."));
 
         /// 더티체킹 수정

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentService.java
@@ -1,5 +1,8 @@
 package bootcamp.kakao.community.platform.posts.comment.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.PostErrorCode;
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
 import bootcamp.kakao.community.common.util.KeyUtil;
@@ -104,7 +107,7 @@ public class CommentService implements CommentUseCase{
         /// 나의 댓글인 지 조회
         /// ID 존재 및 작성 여부를 한번에 파악
         Comment comment = repository.findByUserAndId(user, id)
-                .orElseThrow(() -> new NoSuchElementException("해당 유저가 수정할 댓글이 없습니다."));
+                .orElseThrow(() -> new CustomException(PostErrorCode.FORBIDDEN_COMMENT_EDIT));
 
         /// 더티체킹 수정
         comment.update(request.content());
@@ -122,7 +125,7 @@ public class CommentService implements CommentUseCase{
 
         /// ID 존재 및 작성 여부를 한번에 파악 (영속성 컨테이너)
         Comment comment = repository.findByUserAndId(user, commentId)
-                .orElseThrow(() -> new NoSuchElementException("해당 유저가 삭제할 댓글이 없습니다."));
+                .orElseThrow(() -> new CustomException(PostErrorCode.FORBIDDEN_COMMENT_EDIT));
 
         /// 삭제
         comment.delete();
@@ -141,7 +144,8 @@ public class CommentService implements CommentUseCase{
     @Transactional
     public Comment loadComment(Long commentId) {
         return repository.findById(commentId)
-                .orElseThrow(() -> new NoSuchElementException("해당 아이디를 가진 댓글은 존재하지않습니다."));
+                .orElseThrow(() -> new CustomException(PostErrorCode.NOT_FOUND_COMMENT));
     }
+
 }
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/CommentUseCase.java
@@ -19,7 +19,7 @@ public interface CommentUseCase {
     SliceResponse<CommentListResponse> getFavoriteComments(SliceRequest request, Long postId);
 
     /// 댓글 수정
-    void updateComment(CommentUpdateRequest request, Long userId);
+    void updateComment(Long commentId, CommentUpdateRequest request, Long userId);
 
     /// 댓글 삭제
     void deleteComment(Long commentId, Long userId);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentUpdateRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/application/dto/CommentUpdateRequest.java
@@ -4,9 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "[요청][댓글] 댓글 수정 Request", description = "댓글 수정을 위한 DTO입니다.")
 public record CommentUpdateRequest(
-        @Schema(description = "댓글 아이디", example = "1")
-        Long id,
-
         @Schema(description = "수정할 댓글 내용", example = "수정된 댓글 내용입니다.")
         String content
 ) {

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/CommentApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/CommentApi.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/comment")
+@RequestMapping("/v1/comments")
 public class CommentApi implements CommentApiSpec {
 
     private final CommentUseCase service;
@@ -55,13 +55,14 @@ public class CommentApi implements CommentApiSpec {
     }
 
     /// 댓글 수정
-    @PatchMapping()
+    @PatchMapping("/{commentId}")
     public ApiResponse<Void> updateComment(
+            @PathVariable Long commentId,
             @RequestBody @Valid CommentUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         /// 서비스 실행
-        service.updateComment(request, customUserDetails.getId());
+        service.updateComment(commentId, request, customUserDetails.getId());
 
         /// 리턴
         return ApiResponse.updated();
@@ -69,9 +70,9 @@ public class CommentApi implements CommentApiSpec {
 
 
     /// 댓글 삭제
-    @PutMapping()
+    @PutMapping("/{commentId}")
     public ApiResponse<Void> deleteComment(
-            @RequestParam Long commentId,
+            @PathVariable Long commentId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/swagger/CommentApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/comment/presentation/swagger/CommentApiSpec.java
@@ -5,13 +5,13 @@ import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentListResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentRequest;
-import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentResponse;
 import bootcamp.kakao.community.platform.posts.comment.application.dto.CommentUpdateRequest;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -45,6 +45,7 @@ public interface CommentApiSpec {
             description = "게시글에 따른 댓글을 수정하는 API 입니다."
     )
     ApiResponse<Void> updateComment(
+            @PathVariable Long commentId,
             @RequestBody @Valid CommentUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
@@ -55,6 +56,6 @@ public interface CommentApiSpec {
             description = "게시글에 따른 댓글을 삭제하는 API 입니다."
     )
     ApiResponse<Void> deleteComment(
-            @RequestParam Long commentId,
+            @PathVariable Long commentId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails);
 }

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
@@ -1,5 +1,7 @@
 package bootcamp.kakao.community.platform.posts.post.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.code.PostErrorCode;
 import bootcamp.kakao.community.platform.images.post_images.application.PostImageUseCase;
 import bootcamp.kakao.community.platform.posts.category.application.CategoryUseCase;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
@@ -10,11 +12,8 @@ import bootcamp.kakao.community.platform.posts.post.domain.repository.PostReposi
 import bootcamp.kakao.community.platform.user.application.UserUseCase;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +45,7 @@ public class PostCommandService implements PostCommandUseCase{
         /// 존재한다면
         if (!req.imageUrls().isEmpty()) {
             /// 썸네일 추출
-            thumbnailUrl = req.imageUrls().get(0);
+            thumbnailUrl = req.imageUrls().getFirst();
         }
 
         /// 게시글 객체 생성 및 저장 (영속성 컨테이너)
@@ -74,7 +73,7 @@ public class PostCommandService implements PostCommandUseCase{
 
         /// 동일 유저인지 체크
         if (!post.getUser().getId().equals(user.getId())){
-            throw new AccessDeniedException("수정할 권한이 없습니다.");
+            throw new CustomException(PostErrorCode.FORBIDDEN_POST_EDIT);
         }
 
         /// 게시글 이미지 조회하기 (영속성 컨텍스트)
@@ -99,7 +98,7 @@ public class PostCommandService implements PostCommandUseCase{
 
         /// 동일 유저인지 체크
         if (!post.getUser().getId().equals(user.getId())) {
-            throw new AccessDeniedException("삭제할 권한이 없습니다.");
+            throw new CustomException(PostErrorCode.FORBIDDEN_POST_EDIT);
         }
 
         /// 게시글 수정
@@ -114,7 +113,7 @@ public class PostCommandService implements PostCommandUseCase{
     @Transactional
     protected Post loadPost(Long postId) {
         return repository.findByIdAndDeletedIsFalse(postId)
-                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 게시글이 없습니다."));
+                .orElseThrow(() -> new CustomException(PostErrorCode.NOT_FOUND_POST));
     }
 
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostQueryService.java
@@ -1,5 +1,7 @@
 package bootcamp.kakao.community.platform.posts.post.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.code.PostErrorCode;
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
 import bootcamp.kakao.community.common.util.KeyUtil;
@@ -24,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Slf4j
 @Service
@@ -68,6 +69,7 @@ public class PostQueryService implements PostQueryUseCase{
                 .toList();
 
         /// Redis에 multiGet 요청으로 데이터 한번에 가져오기
+        // !TODO multiGET 대신 Key-value Map으로 변환하고 매칭하는 것으로 수정
         List<String> viewCounts = redisTemplate.opsForValue().multiGet(viewCountKeys);
         List<String> commentCounts = redisTemplate.opsForValue().multiGet(commentCountKeys);
         List<String> likeCounts = redisTemplate.opsForValue().multiGet(likeCountKeys);
@@ -150,7 +152,7 @@ public class PostQueryService implements PostQueryUseCase{
     @Transactional
     public Post loadPost(Long postId) {
         return repository.findByIdAndDeletedIsFalse(postId)
-                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 게시글이 없습니다."));
+                .orElseThrow(() -> new CustomException(PostErrorCode.NOT_FOUND_POST));
     }
 
     // =================

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostRequest.java
@@ -1,7 +1,9 @@
 package bootcamp.kakao.community.platform.posts.post.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
@@ -17,13 +19,14 @@ import java.util.List;
 public record PostRequest(
 
         @NotNull(message = "카테고리없이 게시글을 작성할 수 없습니다.")
+        @Positive(message = "카테고리 Id는 1이상만 가능합니다.")
         Long categoryId,
 
         @Size(max = 26, message = "제목의 길이가 26자를 넘습니다.")
-        @NotNull(message = "제목없이 게시글을 작성할 수 없습니다.")
+        @NotBlank(message = "제목없이 게시글을 작성할 수 없습니다.")
         String title,
 
-        @NotNull(message = "내용없이 게시글을 작성할 수 없습니다.")
+        @NotBlank(message = "내용없이 게시글을 작성할 수 없습니다.")
         String content,
 
         List<String> imageUrls

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post_likes/application/PostLikeService.java
@@ -1,5 +1,8 @@
 package bootcamp.kakao.community.platform.posts.post_likes.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.PostErrorCode;
 import bootcamp.kakao.community.common.util.KeyUtil;
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
@@ -65,8 +68,8 @@ public class PostLikeService implements PostLikeUseCase {
 
         Optional<PostLike> optionalPostLike = repository.findByUserAndPost(user, post);
         if (optionalPostLike.isEmpty()) {
-            /// 없다면 예외처리
-            throw new IllegalStateException("좋아요를 누르지 않았기에 취소가 불가능합니다.");
+            /// 누른 적이 없다면 취소할 수 없다.
+            throw new CustomException(PostErrorCode.BAD_REQUEST_POST_LIKES);
         }
 
         /// 삭제 처리 (바로 삭제)
@@ -126,7 +129,7 @@ public class PostLikeService implements PostLikeUseCase {
 
     private Post loadPost(Long postId) {
         return postRepository.findById(postId)
-                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 게시글이 없습니다."));
+                .orElseThrow(() -> new CustomException(PostErrorCode.NOT_FOUND_POST));
     }
 
     private User loadUser(Long userId) {

--- a/src/main/java/bootcamp/kakao/community/platform/report/application/ReportService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/report/application/ReportService.java
@@ -1,5 +1,8 @@
 package bootcamp.kakao.community.platform.report.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.ReportErrorCode;
 import bootcamp.kakao.community.platform.posts.comment.application.CommentUseCase;
 import bootcamp.kakao.community.platform.posts.post.application.PostQueryUseCase;
 import bootcamp.kakao.community.platform.report.application.dto.ReportRequest;
@@ -42,7 +45,7 @@ public class ReportService implements ReportUseCase {
                 userService.loadUser(request.contentId());
                 break;
             default:
-                throw new IllegalStateException("잘못된 값을 입력했습니다.");
+                throw new CustomException(ReportErrorCode.BAD_REQUEST_REPORT_TYPE);
         }
 
         /// 생성 및 저장

--- a/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/application/UserService.java
@@ -1,5 +1,7 @@
 package bootcamp.kakao.community.platform.user.application;
 
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.code.UserErrorCode;
 import bootcamp.kakao.community.platform.user.application.dto.*;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import bootcamp.kakao.community.platform.user.domain.repository.UserRepository;
@@ -10,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -48,18 +48,18 @@ public class UserService implements UserUseCase{
         /// 이메일 중복체크 및 예외처리
         boolean duplicateEmail = checkDuplicateEmail(request.email());
         if (duplicateEmail) {
-            throw new IllegalArgumentException("이메일이 중복되는 문제입니다.");
+            throw new CustomException(UserErrorCode.CONFLICT_DUPLICATE_EMAIL);
         }
 
         /// 닉네임 중복체크 및 예외처리
         boolean duplicateNickName = checkDuplicateNickName(request.nickname());
         if (duplicateNickName) {
-            throw new IllegalArgumentException("닉네임이 중복되는 문제입니다.");
+            throw new CustomException(UserErrorCode.CONFLICT_DUPLICATE_NICKNAME);
         }
 
         /// 요청한 비밀번호 값이 같은지
         if (!request.confirmPassword().equals(request.password())) {
-            throw new IllegalArgumentException("패스워드가 일치하지 않는 문제입니다.");
+            throw new CustomException(UserErrorCode.BAD_REQUEST_EQUAL_PASSWORD);
         }
 
         /// 유저 저장
@@ -141,14 +141,15 @@ public class UserService implements UserUseCase{
 
         /// 기존 값과 비교해서 변경하기
         if (!passwordEncoder.matches(request.oldPassword(), user.getPassword())) {
-            throw new IllegalStateException("기존 비밀번호와 일치하지 않습니다.");
+            throw new CustomException(UserErrorCode.BAD_REQUEST_OLD_PASSWORD);
         }
 
         /// 변경할 값이 동일한 지 체크
         /// 요청한 비밀번호 값이 같은지
         if (!request.newPassword().equals(request.confirmPassword())) {
-            throw new IllegalArgumentException("패스워드가 일치하지 않는 문제입니다.");
+            throw new CustomException(UserErrorCode.BAD_REQUEST_EQUAL_PASSWORD);
         }
+
         /// 새로운 비밀번호로 업데이트 (더티체킹)
         user.updatePassword(passwordEncoder.encode(request.newPassword()));
 
@@ -160,7 +161,7 @@ public class UserService implements UserUseCase{
     @Override
     public User loadUser(Long userId) {
         return repository.findByIdAndDeletedIsFalse(userId)
-                .orElseThrow(() -> new NoSuchElementException("해당 아이디가 존재하는 유저가 없습니다."));
+                .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND_USER));
     }
 
 }

--- a/src/main/java/bootcamp/kakao/community/platform/user/presentation/UserApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/presentation/UserApi.java
@@ -1,5 +1,6 @@
 package bootcamp.kakao.community.platform.user.presentation;
 
+import bootcamp.kakao.community.common.aop.NonNullUser;
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.platform.user.application.UserUseCase;
 import bootcamp.kakao.community.platform.user.application.dto.*;
@@ -88,8 +89,10 @@ public class UserApi implements UserApiSpec {
     }
 
     /// 나의 정보 조회하기
+    @NonNullUser
     @GetMapping("/mypage")
-    public ApiResponse<MyPageResponse> getUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ApiResponse<MyPageResponse> getUser(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         /// 서비스 로직
         MyPageResponse user = service.getUser(customUserDetails.getId());

--- a/src/main/java/bootcamp/kakao/community/security/auth/application/AuthService.java
+++ b/src/main/java/bootcamp/kakao/community/security/auth/application/AuthService.java
@@ -1,6 +1,9 @@
 package bootcamp.kakao.community.security.auth.application;
 
-import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.common.response.code.SecurityErrorCode;
+import bootcamp.kakao.community.common.response.code.UserErrorCode;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import bootcamp.kakao.community.platform.user.domain.repository.UserRepository;
 import bootcamp.kakao.community.security.auth.application.dto.LoginRequest;
@@ -41,11 +44,11 @@ public class AuthService implements AuthUseCase {
 
         /// DB 검증
         User user = repository.findByEmail(request.email())
-                .orElseThrow(() -> new NoSuchElementException("해당 이메일을 가진 유저가 없습니다"));
+                .orElseThrow(() -> new CustomException(SecurityErrorCode.NOT_FOUND_EMAIL));
 
         /// 패스워드 비교
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new IllegalArgumentException("로그인할 수 없습니다.");
+            throw new CustomException(SecurityErrorCode.BAD_REQUEST_LOGIN);
         }
 
         /// 로그인했다면, JWT 발급하기
@@ -64,25 +67,25 @@ public class AuthService implements AuthUseCase {
 
         /// DB 검증
         User user = repository.findByIdAndDeletedIsFalse(userId)
-                .orElseThrow(() -> new NoSuchElementException("해당 고유번호를 가진 유저가 없습니다"));
+                .orElseThrow(() -> new NoSuchElementException(UserErrorCode.NOT_FOUND_USER.getMessage()));
 
         /// 없다면 예외처리
         if (refreshToken.isEmpty()) {
-            throw new JwtAuthenticationException(ErrorCode.REFRESH_INVALID_LOGIN);
+            throw new JwtAuthenticationException(SecurityErrorCode.REFRESH_INVALID_LOGIN);
         }
 
         /// 레디스에서 삭제하도록 로직 수행
-        jwtValidator.removeRefreshToken(userId, deviceType, refreshToken.get());
+        jwtValidator.removeRefreshToken(user.getId(), deviceType, refreshToken.get());
     }
 
     /// 토큰 재발급
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public JwtTokenResponse reissue(String deviceType, Optional<String> refreshToken) {
 
         /// 없다면 예외처리
         if (refreshToken.isEmpty()) {
-            throw new JwtAuthenticationException(ErrorCode.REFRESH_INVALID_LOGIN);
+            throw new JwtAuthenticationException(SecurityErrorCode.REFRESH_INVALID_LOGIN);
         }
 
         /// 존재하는 리프레쉬 토큰 검증
@@ -90,14 +93,22 @@ public class AuthService implements AuthUseCase {
 
         /// 리프레쉬 토큰 바탕으로 조회
         User user = repository.findById(token.getUserId())
-                .orElseThrow(() -> new NoSuchElementException("해당 아이디를 가진 유저가 없습니다"));
+                .orElseThrow(() -> new CustomException(SecurityErrorCode.NOT_FOUND_ID));
+
 
         /// 인증된 유저에게 JWT 발급하기
         var jwtRequest = JwtTokenRequest.from(user);
 
-        String newAccessToken = jwtProvider.createAccessToken(jwtRequest);
+        /// 기존 리프레쉬 토큰 무효화하기 (RDB)
+        jwtValidator.removeRefreshToken(user.getId(), deviceType, token.getRefreshToken());
 
-        return JwtTokenResponse.of(newAccessToken, null);
+        /// 새로운 액세스토큰/리프레쉬 토큰 발급
+        String newAccessToken = jwtProvider.createAccessToken(jwtRequest);
+        String newRefreshToken = jwtProvider.createRefreshToken(deviceType, jwtRequest);
+
+
+
+        return JwtTokenResponse.of(newAccessToken, newRefreshToken);
     }
 }
 

--- a/src/main/java/bootcamp/kakao/community/security/auth/presentation/AuthApi.java
+++ b/src/main/java/bootcamp/kakao/community/security/auth/presentation/AuthApi.java
@@ -97,6 +97,7 @@ public class AuthApi implements AuthApiSpec {
 
         /// 액세스 쿠키로 전송하기
         httpUtil.addAccessTokenHeader(httpServletResponse, response.accessToken());
+        httpUtil.addRefreshTokenCookie(httpServletResponse, response.refreshToken());
 
         /// 리턴
         return ApiResponse.updated();

--- a/src/main/java/bootcamp/kakao/community/security/config/RequestMatcherHolder.java
+++ b/src/main/java/bootcamp/kakao/community/security/config/RequestMatcherHolder.java
@@ -1,4 +1,4 @@
-package bootcamp.kakao.community.security.jwt.filter;
+package bootcamp.kakao.community.security.config;
 
 import bootcamp.kakao.community.platform.user.domain.entity.UserRole;
 import io.micrometer.common.lang.Nullable;

--- a/src/main/java/bootcamp/kakao/community/security/config/SecurityConfig.java
+++ b/src/main/java/bootcamp/kakao/community/security/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package bootcamp.kakao.community.security.config;
 import bootcamp.kakao.community.security.jwt.filter.JwtDeniedHandler;
 import bootcamp.kakao.community.security.jwt.filter.JwtFailureHandler;
 import bootcamp.kakao.community.security.jwt.filter.JwtFilter;
+import bootcamp.kakao.community.security.jwt.filter.RequestMatcherHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import static bootcamp.kakao.community.platform.user.domain.entity.UserRole.ADMIN;
+import static bootcamp.kakao.community.platform.user.domain.entity.UserRole.MEMBER;
+
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
@@ -21,7 +25,9 @@ public class SecurityConfig {
     private final JwtFailureHandler jwtFailureHandler;
     private final JwtDeniedHandler jwtDeniedHandler;
 
+    private final RequestMatcherHolder requestMatcherHolder;
     private final CorsConfigurationSource corsConfigurationSource;
+
     /**
      * SecurityFilterChain 설정
      */
@@ -34,8 +40,15 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(AbstractHttpConfigurer::disable)
-                /// 인가
-                .authorizeHttpRequests(req -> req.requestMatchers("/**").permitAll())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(requestMatcherHolder.getRequestMatchersByMinRole(null))
+                        .permitAll()
+                        .requestMatchers(requestMatcherHolder.getRequestMatchersByMinRole(MEMBER))
+                        .hasAnyAuthority(ADMIN.getRole(), MEMBER.getRole())
+                        .requestMatchers(requestMatcherHolder.getRequestMatchersByMinRole(ADMIN))
+                        .hasAnyAuthority(ADMIN.getRole())
+                        .anyRequest().authenticated()
+                )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class) /// UsernamePasswordAuthenticationFilter.class 전에 실행하도록
                 .exceptionHandling(exception -> {
                     exception.authenticationEntryPoint(jwtFailureHandler)
@@ -54,3 +67,4 @@ public class SecurityConfig {
 
 
 }
+

--- a/src/main/java/bootcamp/kakao/community/security/config/SecurityConfig.java
+++ b/src/main/java/bootcamp/kakao/community/security/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package bootcamp.kakao.community.security.config;
 import bootcamp.kakao.community.security.jwt.filter.JwtDeniedHandler;
 import bootcamp.kakao.community.security.jwt.filter.JwtFailureHandler;
 import bootcamp.kakao.community.security.jwt.filter.JwtFilter;
-import bootcamp.kakao.community.security.jwt.filter.RequestMatcherHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/bootcamp/kakao/community/security/jwt/application/JwtValidator.java
+++ b/src/main/java/bootcamp/kakao/community/security/jwt/application/JwtValidator.java
@@ -1,6 +1,7 @@
 package bootcamp.kakao.community.security.jwt.application;
 
-import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.common.response.code.SecurityErrorCode;
 import bootcamp.kakao.community.platform.user.domain.entity.User;
 import bootcamp.kakao.community.platform.user.domain.repository.UserRepository;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
@@ -54,27 +55,27 @@ public class JwtValidator {
 
         } catch (ExpiredJwtException e) {
             /// 만료된 토큰
-            throw new JwtAuthenticationException(ErrorCode.ACCESS_TOKEN_EXPIRED);
+            throw new JwtAuthenticationException(SecurityErrorCode.ACCESS_TOKEN_EXPIRED);
 
         } catch (SignatureException e) {
             /// 잘못된 서명
-            throw new JwtAuthenticationException(ErrorCode.ACCESS_TOKEN_INVALID);
+            throw new JwtAuthenticationException(SecurityErrorCode.ACCESS_TOKEN_INVALID);
 
         } catch (MalformedJwtException e) {
             //// 구조가 깨진 토큰
-            throw new JwtAuthenticationException(ErrorCode.ACCESS_TOKEN_MALFORMED);
+            throw new JwtAuthenticationException(SecurityErrorCode.ACCESS_TOKEN_MALFORMED);
 
         } catch (UnsupportedJwtException e) {
             /// 지원되지 않는 JWT 형식 (예: 압축/암호화된 JWT)
-            throw new JwtAuthenticationException(ErrorCode.ACCESS_TOKEN_UNSUPPORTED);
+            throw new JwtAuthenticationException(SecurityErrorCode.ACCESS_TOKEN_UNSUPPORTED);
 
         } catch (IllegalArgumentException e) {
             /// 토큰이 비어있거나 null
-            throw new JwtAuthenticationException(ErrorCode.ACCESS_TOKEN_NOT_FOUND);
+            throw new JwtAuthenticationException(SecurityErrorCode.ACCESS_TOKEN_NOT_FOUND);
 
         } catch (JwtException e) {
             /// JWT 관련 기타 예외 (상위 클래스)
-            throw new JwtAuthenticationException(ErrorCode.ACCESS_TOKEN_INVALID);
+            throw new JwtAuthenticationException(SecurityErrorCode.ACCESS_TOKEN_INVALID);
 
         } catch (JwtAuthenticationException e) {
             /// 커스텀 JWT 예외 (예: USER_NOT_FOUND 등)
@@ -82,7 +83,7 @@ public class JwtValidator {
 
         } catch (Exception e) {
             /// 예상치 못한 모든 예외
-            throw new JwtAuthenticationException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new JwtAuthenticationException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -98,21 +99,21 @@ public class JwtValidator {
 
             /// 리턴
             return repository.findByRefreshTokenAndDeviceTypeAndUserId(refreshToken, deviceType, userId)
-                    .orElseThrow(() -> new JwtAuthenticationException(ErrorCode.REFRESH_INVALID_LOGIN));
+                    .orElseThrow(() -> new JwtAuthenticationException(SecurityErrorCode.REFRESH_INVALID_LOGIN));
 
 
         } catch (ExpiredJwtException e) {
             // 토큰이 '만료'된 경우의 처리
-            throw new JwtAuthenticationException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+            throw new JwtAuthenticationException(SecurityErrorCode.REFRESH_TOKEN_EXPIRED);
         } catch (SignatureException e) {
             // 서명이 잘못된 경우의 처리
-            throw new JwtAuthenticationException(ErrorCode.REFRESH_TOKEN_INVALID);
+            throw new JwtAuthenticationException(SecurityErrorCode.REFRESH_TOKEN_INVALID);
         } catch (MalformedJwtException e) {
             // 토큰 구조가 잘못된 경우의 처리
-            throw new JwtAuthenticationException(ErrorCode.REFRESH_TOKEN_UNSUPPORTED);
+            throw new JwtAuthenticationException(SecurityErrorCode.REFRESH_TOKEN_UNSUPPORTED);
         } catch (Exception e) {
             // 기타 예외 처리
-            throw new JwtAuthenticationException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new JwtAuthenticationException(CommonErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -127,7 +128,7 @@ public class JwtValidator {
 
         /// 유저가 다르다면, 예외 발생
         if (!userIdFromAccessToken.equals(userId)) {
-            throw new JwtAuthenticationException(ErrorCode.REFRESH_TOKEN_INVALID);
+            throw new JwtAuthenticationException(SecurityErrorCode.REFRESH_TOKEN_INVALID);
         }
 
         /// 레디스에서 토큰 삭제

--- a/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtAuthenticationException.java
+++ b/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtAuthenticationException.java
@@ -1,6 +1,8 @@
 package bootcamp.kakao.community.security.jwt.filter;
 
 import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.common.response.code.SecurityErrorCode;
 import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;
 

--- a/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtDeniedHandler.java
+++ b/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtDeniedHandler.java
@@ -2,7 +2,7 @@ package bootcamp.kakao.community.security.jwt.filter;
 
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.CustomException;
-import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,9 +24,8 @@ public class JwtDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
 
-
-        // 권한 부족 403 Error
-        CustomException exception = new CustomException(ErrorCode.FORBIDDEN, null);
+        /// 권한 부족 403 Error
+        CustomException exception = new CustomException(CommonErrorCode.FORBIDDEN);
         ApiResponse<Object> apiResponse = ApiResponse.fail(exception);
 
         /// response 제작

--- a/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtDeniedHandler.java
+++ b/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtDeniedHandler.java
@@ -1,5 +1,7 @@
 package bootcamp.kakao.community.security.jwt.filter;
 
+import bootcamp.kakao.community.common.logging.HttpLogUtil;
+import bootcamp.kakao.community.common.logging.LogType;
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.CustomException;
 import bootcamp.kakao.community.common.response.code.CommonErrorCode;
@@ -19,6 +21,7 @@ import java.io.IOException;
 public class JwtDeniedHandler implements AccessDeniedHandler {
 
     private final ObjectMapper objectMapper;
+    private final HttpLogUtil logUtil;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
@@ -32,6 +35,9 @@ public class JwtDeniedHandler implements AccessDeniedHandler {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+
+        /// 로그 찍기
+        logUtil.logHttpRequest(request, LogType.ERROR_403.getLabel());
 
         // JSON 응답
         objectMapper.writeValue(response.getWriter(), apiResponse);

--- a/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtFailureHandler.java
+++ b/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtFailureHandler.java
@@ -1,25 +1,30 @@
 package bootcamp.kakao.community.security.jwt.filter;
 
+import bootcamp.kakao.community.common.logging.HttpLogUtil;
+import bootcamp.kakao.community.common.logging.LogType;
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.CustomException;
 import bootcamp.kakao.community.common.response.code.CommonErrorCode;
 import bootcamp.kakao.community.common.response.code.SecurityErrorCode;
+import bootcamp.kakao.community.common.util.HttpUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtFailureHandler implements AuthenticationEntryPoint {
 
-
     private final ObjectMapper objectMapper;
+    private final HttpLogUtil logUtil;
 
     @Override
     public void commence(HttpServletRequest request,
@@ -40,6 +45,9 @@ public class JwtFailureHandler implements AuthenticationEntryPoint {
         response.setStatus(apiResponse.httpStatus().value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+
+        // 로그 찍기
+        logUtil.logHttpRequest(request, LogType.ERROR_401.getLabel());
 
         // JSON 응답
         objectMapper.writeValue(response.getWriter(), apiResponse);

--- a/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtFailureHandler.java
+++ b/src/main/java/bootcamp/kakao/community/security/jwt/filter/JwtFailureHandler.java
@@ -2,7 +2,8 @@ package bootcamp.kakao.community.security.jwt.filter;
 
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.CustomException;
-import bootcamp.kakao.community.common.response.ErrorCode;
+import bootcamp.kakao.community.common.response.code.CommonErrorCode;
+import bootcamp.kakao.community.common.response.code.SecurityErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,16 +26,12 @@ public class JwtFailureHandler implements AuthenticationEntryPoint {
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
-        /// 401 Error 발생
-        CustomException exception ;
+        /// 인증 문제 발생시, 401 Error 발생
+        CustomException exception = new CustomException(CommonErrorCode.UNAUTHORIZED);
 
         /// JWT 예외인 경우
         if (authException instanceof JwtAuthenticationException jwtEx) {
-            exception = new CustomException(jwtEx.getErrorCode(), null);
-        }
-        /// 인증 자체가 없는 경우 (로그인 안 됨)
-        else {
-            exception = new CustomException(ErrorCode.ACCESS_TOKEN_NOT_FOUND, null);
+            exception = new CustomException(jwtEx.getErrorCode());
         }
 
         ApiResponse<Object> apiResponse = ApiResponse.fail(exception);

--- a/src/main/java/bootcamp/kakao/community/security/jwt/filter/RequestMatcherHolder.java
+++ b/src/main/java/bootcamp/kakao/community/security/jwt/filter/RequestMatcherHolder.java
@@ -1,0 +1,124 @@
+package bootcamp.kakao.community.security.jwt.filter;
+
+import bootcamp.kakao.community.platform.user.domain.entity.UserRole;
+import io.micrometer.common.lang.Nullable;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.springframework.http.HttpMethod.*;
+
+@Component
+public class RequestMatcherHolder {
+
+    private static final List<RequestInfo> REQUEST_INFO_LIST = List.of(
+
+            // 공통
+            new RequestInfo(OPTIONS, "/**", null),
+            new RequestInfo(GET, "/", null),
+
+            /// 인증
+            new RequestInfo(PUT, "/v1/auth", null),     /// 재발급
+            new RequestInfo(POST, "/v1/auth", null),     /// 로그인
+            new RequestInfo(DELETE, "/v1/auth", UserRole.MEMBER),     /// 로그아웃
+
+            /// 카테고리
+            new RequestInfo(PUT, "/v1/category", null),     /// 조회
+            new RequestInfo(POST, "/v1/category", UserRole.ADMIN),     /// 생성
+            new RequestInfo(DELETE, "/v1/category", UserRole.ADMIN),     /// 삭제
+
+            /// 게시글
+            new RequestInfo(GET, "/v1/posts/**", null),     /// 목록조회
+            new RequestInfo(PUT, "/v1/posts", UserRole.MEMBER),     /// 삭제
+            new RequestInfo(GET, "/v1/posts", null),        /// 상세 조회
+            new RequestInfo(POST, "/v1/posts", UserRole.MEMBER),     /// 작성
+            new RequestInfo(PATCH, "/v1/posts", UserRole.MEMBER),     /// 수정
+
+            /// 이미지
+            new RequestInfo(GET, "/v1/images", UserRole.MEMBER),     /// 이미지 주소
+            new RequestInfo(GET, "/v1/images/temp", null),     /// 회원가입용
+
+            /// 유저
+            new RequestInfo(PUT, "/v1/users", UserRole.MEMBER),              /// 회원탈퇴
+            new RequestInfo(POST, "/v1/users", null),                /// 회원가입
+            new RequestInfo(PUT, "/v1/users/password", UserRole.MEMBER),     /// 비밀번호 수정
+            new RequestInfo(GET, "/v1/users/mypage", UserRole.MEMBER),       /// 내 정보
+            new RequestInfo(PUT, "/v1/users/mypage", UserRole.MEMBER),       /// 내 정보 수정
+            new RequestInfo(GET, "/v1/users/{userId}", null),        /// 다른 정보
+            new RequestInfo(GET, "/v1/users/nickname", null),        /// 닉네임 중복 여부
+            new RequestInfo(GET, "/v1/users/email", null),           /// 이메일 중복 여부
+
+            /// 댓글
+            new RequestInfo(GET, "/v1/comments", null),                 /// 댓글조회
+            new RequestInfo(PUT, "/v1/comments", UserRole.MEMBER),              /// 댓글삭제
+            new RequestInfo(POST, "/v1/comments", UserRole.MEMBER),              /// 댓글작성
+            new RequestInfo(PATCH, "/v1/comments", UserRole.MEMBER),              /// 댓글수정
+
+            /// 신고
+            new RequestInfo(POST, "/v1/report", UserRole.MEMBER),              /// 신고
+
+            /// 좋아요
+            new RequestInfo(POST, "/v1/posts/likes", UserRole.MEMBER),              /// 좋아요
+            new RequestInfo(DELETE, "/v1/posts/likes", UserRole.MEMBER),            /// 좋아요 취소
+
+
+            // static resources
+            new RequestInfo(GET, "/docs/**", null),
+            new RequestInfo(GET, "/*.ico", null),
+            new RequestInfo(GET, "/resources/**", null),
+            new RequestInfo(GET, "/style.css", null),
+            new RequestInfo(GET, "/index.html", null),
+            new RequestInfo(GET, "/error", null),
+
+            // Swagger UI 및 API 문서 관련 요청
+            new RequestInfo(GET, "/v3/api-docs/**", null),
+            new RequestInfo(GET, "/swagger-ui/**", null),
+            new RequestInfo(GET, "/swagger-resources/**", null),
+            new RequestInfo(GET, "/webjars/**", null),
+            new RequestInfo(GET, "/swagger-ui.html", null),
+
+            // 정적 아이콘 요청
+            new RequestInfo(GET, "/favicon.ico", null),
+            new RequestInfo(GET, "/apple-touch-icon.png", null)
+
+    );
+
+
+
+
+
+    private final ConcurrentHashMap<String, RequestMatcher> reqMatcherCacheMap = new ConcurrentHashMap<>();
+
+    /// 최소 권한이 주어진 요청에 대한 RequestMatcher 반환
+    public RequestMatcher getRequestMatchersByMinRole(@Nullable UserRole minRole) {
+        var key = getKeyByRole(minRole);
+        return reqMatcherCacheMap.computeIfAbsent(key, k ->
+                new OrRequestMatcher(REQUEST_INFO_LIST.stream()
+                        .filter(reqInfo -> isAccessible(reqInfo.minRole(), minRole))
+                        .map(reqInfo -> new AntPathRequestMatcher(reqInfo.pattern(),
+                                reqInfo.method().name()))
+                        .toArray(AntPathRequestMatcher[]::new)));
+    }
+
+    /// 접근 가능한지
+    private boolean isAccessible(@Nullable UserRole requiredRole, @Nullable UserRole currentRole) {
+        if (requiredRole == null) return true; // 누구나 접근 가능
+        if (currentRole == null) return false; // 권한 없음
+        return currentRole.ordinal() >= requiredRole.ordinal(); // ADMIN이면 MEMBER 포함
+    }
+
+    /// 롤 가져오기
+    private String getKeyByRole(@Nullable UserRole minRole) {
+        return minRole == null ? "VISITOR" : minRole.name();
+    }
+
+    /// 역할 가져오기
+    private record RequestInfo(HttpMethod method, String pattern, UserRole minRole) {}
+
+}
+


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 도메인별 에러코드 클래스를 생성했습니다.
- 댓글 API의 입력 파라미터를 수정했습니다.
- 변경된 에러코드에 따라 전반적인 코드 리팩토링을 진행했습니다.
- JWT 관련 예외처리를 핸들러에서 처리하도록 변경했습니다.
- HTTP 요청 로깅 기능을 추가했습니다.
- 게시글 API의 @Valid 검증 구조를 수정했습니다.
- 시큐리티 인증/인가 로직을 추가했습니다.
- @AuthenticationPrincipal의 Null 방지 어노테이션을 추가했습니다.
- RequestMatcherHolder 파일의 경로를 이동했습니다.

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 인증/인가 관련 리팩토링으로 기존 필터 체인 및 시큐리티 설정 코드의 의존성이 변경되었습니다.
- 에러코드 클래스 추가에 따라 GlobalExceptionHandler 동작이 일부 조정되었습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

- 파라미터 실패
<img width="942" height="1568" alt="스크린샷 2025-10-22 15 38 17" src="https://github.com/user-attachments/assets/ae59f124-9ddf-486f-a2e3-eb083b68b531" />

- 일반 401 에러
<img width="942" height="1568" alt="스크린샷 2025-10-22 15 40 47" src="https://github.com/user-attachments/assets/6b55141a-556d-4e80-8074-e27ff9d0f1b6" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#30 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
