### PR TITLE
♻️ refactor : 게시글 응답 수정 및 회원가입 이미지 수정

### DIFF
--- a/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/bootcamp/kakao/community/common/exception/GlobalExceptionHandler.java
@@ -36,6 +36,9 @@ public class GlobalExceptionHandler {
         /// 에러 코드
         ErrorCode errorCode = e.getErrorCode();
 
+        /// 로그찍기
+        log.error(errorCode.getMessage());
+
         /// 응답
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/main/java/bootcamp/kakao/community/common/logging/HttpLogUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/logging/HttpLogUtil.java
@@ -16,11 +16,14 @@ public class HttpLogUtil {
     /// HTTP 대한 로그를 찍는 것
     public void logHttpRequest(HttpServletRequest httpServletRequest, String type) {
 
+        /// 바디
+        var body = httpServletRequest.getContentType();
+
         /// 헤더에서 요청 정보 가져오기
         var clientInfo = httpUtil.getClientInfo(httpServletRequest);
 
         /// 로그
-        log.info("{} : {}, [{}], {}, {}", type, clientInfo.ip(), clientInfo.httpMethod(), clientInfo.uri(), clientInfo.userName());
+        log.info("{} : {}, [{}], {}, {} ,{}", type, clientInfo.ip(), clientInfo.httpMethod(), clientInfo.uri(), clientInfo.userName(), body);
 
     }
 

--- a/src/main/java/bootcamp/kakao/community/common/util/ImageUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/util/ImageUtil.java
@@ -8,29 +8,27 @@ import java.util.UUID;
 @Component
 public class ImageUtil {
 
-    @Value("${cloud.aws.S3.bucket}")
     private static String bucketName;
-
-    @Value("${cloud.aws.region.static}")
     private static String region;
 
-    /// 파일 이름을 고유하게 생성하는 메서드
-    public String generateKey(String file) {
+    @Value("${cloud.aws.S3.bucket}")
+    public void setBucketName(String bucket) {
+        ImageUtil.bucketName = bucket;
+    }
 
-        /// 랜덤 UUID
+    @Value("${cloud.aws.region.static}")
+    public void setRegion(String region) {
+        ImageUtil.region = region;
+    }
+
+    public static String generateKey(String fileName) {
         String key = UUID.randomUUID().toString();
-
-        /// 확장자 처리
-        String extension = file.substring(file.lastIndexOf(".") + 1);
-
+        String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
         return key + "." + extension;
     }
 
-    /// key 바탕으로 퍼블릭 URL 접근하기
     public static String getUrlByKey(String key) {
-
-        /// 응답
         return "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + key;
     }
-
 }
+

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageService.java
@@ -3,8 +3,10 @@ package bootcamp.kakao.community.platform.images.image.application;
 import bootcamp.kakao.community.common.response.CustomException;
 import bootcamp.kakao.community.common.response.code.ImageErrorCode;
 import bootcamp.kakao.community.common.response.code.UserErrorCode;
+import bootcamp.kakao.community.common.util.ImageUtil;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.ConfirmImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.PreSignedImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.response.ImageResponse;
 import bootcamp.kakao.community.platform.images.image.application.dto.response.PreSignedImageResponse;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.ConfirmTempImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.PreSignedTempImageRequest;
@@ -63,16 +65,18 @@ public class ImageService implements ImageUseCase {
     /// 일단은 S3에 올라가는 것이 된다.
     @Override
     @Transactional
-    public void confirmTempImage(ConfirmTempImageRequest request) throws IOException {
+    public ImageResponse confirmTempImage(ConfirmTempImageRequest request) throws IOException {
 
         /// key값으로 임시 이미지 저장하기
         Image reqImage = Image.temporaryOf(request.key());
 
         /// 이미지 저장하기
-        repository.save(reqImage);
+        Image image = repository.save(reqImage);
 
+        /// 리턴
+        return ImageResponse.from(ImageUtil.getUrlByKey(image.getKey()));
     }
-
+    
     /// 여러 개의 이미지를 DB에 저장하는 로직
     /// 일단은 S3에 올라가는 것이 된다.
     @Override

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/application/ImageUseCase.java
@@ -2,6 +2,7 @@ package bootcamp.kakao.community.platform.images.image.application;
 
 import bootcamp.kakao.community.platform.images.image.application.dto.request.ConfirmImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.PreSignedImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.response.ImageResponse;
 import bootcamp.kakao.community.platform.images.image.application.dto.response.PreSignedImageResponse;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.ConfirmTempImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.PreSignedTempImageRequest;
@@ -23,7 +24,7 @@ public interface ImageUseCase {
     PreSignedImageResponse uploadTemporaryImage(PreSignedTempImageRequest req) throws IOException;
 
     /// 임시 이미지를 확정하는 메서드
-    void confirmTempImage(ConfirmTempImageRequest request) throws IOException;
+    ImageResponse confirmTempImage(ConfirmTempImageRequest request) throws IOException;
 
     /// 여러 이미지를 확정하는 메서드
     void confirmImages(ConfirmImageRequest request, Long userId) throws IOException;

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/ImageApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/ImageApi.java
@@ -6,6 +6,7 @@ import bootcamp.kakao.community.platform.images.image.application.dto.request.Co
 import bootcamp.kakao.community.platform.images.image.application.dto.request.PreSignedImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.ConfirmTempImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.PreSignedTempImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.response.ImageResponse;
 import bootcamp.kakao.community.platform.images.image.application.dto.response.PreSignedImageResponse;
 import bootcamp.kakao.community.platform.images.image.presentation.swagger.ImageApiSpec;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
@@ -59,14 +60,14 @@ public class ImageApi implements ImageApiSpec {
      * 회원가입에서 사용하는 임시 이미지 발급한 것을 S3에 저장함
      */
     @PatchMapping("/temp")
-    public ApiResponse<Void> confirm(
+    public ApiResponse<ImageResponse> confirm(
             @RequestBody @Valid ConfirmTempImageRequest request) throws IOException {
 
         /// 서비스
-        service.confirmTempImage(request);
+        var response = service.confirmTempImage(request);
 
         /// 응답 리턴
-        return ApiResponse.updated();
+        return ApiResponse.ok(response);
 
     }
 

--- a/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/swagger/ImageApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/image/presentation/swagger/ImageApiSpec.java
@@ -5,6 +5,7 @@ import bootcamp.kakao.community.platform.images.image.application.dto.request.Co
 import bootcamp.kakao.community.platform.images.image.application.dto.request.PreSignedImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.ConfirmTempImageRequest;
 import bootcamp.kakao.community.platform.images.image.application.dto.request.temp.PreSignedTempImageRequest;
+import bootcamp.kakao.community.platform.images.image.application.dto.response.ImageResponse;
 import bootcamp.kakao.community.platform.images.image.application.dto.response.PreSignedImageResponse;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,7 +40,7 @@ public interface ImageApiSpec {
             summary = "회원가입용 임시 파일 업로드용 저장 API",
             description = "S3에 올린 것을 확정합니다."
     )
-    ApiResponse<Void> confirm(@RequestBody @Valid ConfirmTempImageRequest request) throws IOException;
+    ApiResponse<ImageResponse> confirm(@RequestBody @Valid ConfirmTempImageRequest request) throws IOException;
 
 
     @Operation(

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
@@ -67,16 +67,16 @@ public class PostCommandService implements PostCommandUseCase{
     /// 더티체킹으로 실행
     @Override
     @Transactional
-    public void update(PostUpdateRequest req, Long userId) {
+    public void update(Long postId, PostUpdateRequest req, Long userId) {
 
         /// 게시글 상세 조회 (영속성 컨테이너에 스냅샷)
-        Post post = loadPost(req.id());
+        Post post = loadPost(postId);
 
         /// 유저 예외 처리
         User user = loadUser(userId);
 
         /// 동일 유저인지 체크
-        if (!post.getUser().getId().equals(user.getId())){
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new AccessDeniedException("수정할 권한이 없습니다.");
         }
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandService.java
@@ -4,6 +4,7 @@ import bootcamp.kakao.community.platform.images.post_images.application.PostImag
 import bootcamp.kakao.community.platform.posts.category.application.CategoryUseCase;
 import bootcamp.kakao.community.platform.posts.category.domain.entity.Category;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostSaveResponse;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
 import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
 import bootcamp.kakao.community.platform.posts.post.domain.repository.PostRepository;
@@ -32,7 +33,7 @@ public class PostCommandService implements PostCommandUseCase{
     /// 게시글 작성, 다중 이미지 고려해서 작성
     @Override
     @Transactional
-    public void create(PostRequest req, Long userId) {
+    public PostSaveResponse create(PostRequest req, Long userId) {
 
         /// 카테고리 예외처리
         Category category = loadCategory(req.categoryId());
@@ -57,6 +58,8 @@ public class PostCommandService implements PostCommandUseCase{
         /// 하나라도 에러나면, 롤백 처리
         postImageService.savePostImage(post, req.imageUrls());
 
+        /// 리턴
+        return PostSaveResponse.from(post);
     }
 
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandUseCase.java
@@ -1,12 +1,13 @@
 package bootcamp.kakao.community.platform.posts.post.application;
 
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.PostSaveResponse;
 import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
 
 public interface PostCommandUseCase {
 
     /// 글 작성
-    void create(PostRequest req, Long userId);
+    PostSaveResponse create(PostRequest req, Long userId);
 
     /// 게시글 수정하기
     void update(PostUpdateRequest req, Long userId);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandUseCase.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/PostCommandUseCase.java
@@ -10,7 +10,7 @@ public interface PostCommandUseCase {
     PostSaveResponse create(PostRequest req, Long userId);
 
     /// 게시글 수정하기
-    void update(PostUpdateRequest req, Long userId);
+    void update(Long postId, PostUpdateRequest req, Long userId);
 
     /// 게시글 삭제하기
     void delete(Long postId, Long userId);

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostSaveResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostSaveResponse.java
@@ -1,0 +1,18 @@
+package bootcamp.kakao.community.platform.posts.post.application.dto;
+
+import bootcamp.kakao.community.platform.posts.post.domain.entity.Post;
+import lombok.Builder;
+
+@Builder
+public record PostSaveResponse(
+        Long postId
+) {
+
+    /// 정적 팩토리 메서드
+    public static PostSaveResponse from(Post post) {
+        return PostSaveResponse.builder()
+                .postId(post.getId())
+                .build();
+    }
+
+}

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/application/dto/PostUpdateRequest.java
@@ -6,9 +6,6 @@ import java.util.List;
 
 @Schema(name = "[요청][게시글] 게시글 수정 Request", description = "게시글 수정을 위한 요청 DTO입니다.")
 public record PostUpdateRequest(
-        @Schema(description = "게시글 ID", example = "1")
-        Long id,
-
         @Schema(description = "카테고리 ID", example = "1001")
         Long categoryId,
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
@@ -67,13 +67,14 @@ public class PostApi implements PostApiSpec {
 
 
     /// 글 수정
-    @PatchMapping()
+    @PatchMapping("/{postId}")
     public ApiResponse<Void> updatePost(
+            @PathVariable Long postId,
             @RequestBody @Valid PostUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         /// 서비스 수정
-        commandService.update(request, customUserDetails.getId());
+        commandService.update(postId, request, customUserDetails.getId());
 
         /// 리턴
         return ApiResponse.updated();

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/PostApi.java
@@ -5,10 +5,7 @@ import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
 import bootcamp.kakao.community.platform.posts.post.application.PostCommandUseCase;
 import bootcamp.kakao.community.platform.posts.post.application.PostQueryUseCase;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.*;
 import bootcamp.kakao.community.platform.posts.post.presentation.swagger.PostApiSpec;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -26,15 +23,15 @@ public class PostApi implements PostApiSpec {
 
     /// 글 작성
     @PostMapping
-    public ApiResponse<Void> createPost(
+    public ApiResponse<PostSaveResponse> createPost(
             @RequestBody @Valid PostRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         /// 서비스 작성
-        commandService.create(request, customUserDetails.getId());
+        var response = commandService.create(request, customUserDetails.getId());
 
         /// 리턴
-        return ApiResponse.created();
+        return ApiResponse.created(response);
     }
 
     /// 글 상세 조회

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
@@ -51,6 +51,7 @@ public interface PostApiSpec {
             description = "게시글을 수정하는 API 입니다."
     )
     ApiResponse<Void> updatePost(
+            @PathVariable Long postId,
             @RequestBody @Valid PostUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails);
 

--- a/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
+++ b/src/main/java/bootcamp/kakao/community/platform/posts/post/presentation/swagger/PostApiSpec.java
@@ -3,10 +3,7 @@ package bootcamp.kakao.community.platform.posts.post.presentation.swagger;
 import bootcamp.kakao.community.common.response.ApiResponse;
 import bootcamp.kakao.community.common.response.paging.SliceRequest;
 import bootcamp.kakao.community.common.response.paging.SliceResponse;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostDetailResponse;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostListResponse;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostRequest;
-import bootcamp.kakao.community.platform.posts.post.application.dto.PostUpdateRequest;
+import bootcamp.kakao.community.platform.posts.post.application.dto.*;
 import bootcamp.kakao.community.security.auth.domain.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,7 +21,7 @@ public interface PostApiSpec {
             summary = "게시글 작성 API",
             description = "게시글을 작성하는 API 입니다."
     )
-    ApiResponse<Void> createPost(
+    ApiResponse<PostSaveResponse> createPost(
             @RequestBody @Valid PostRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails);
 

--- a/src/main/java/bootcamp/kakao/community/platform/user/domain/repository/UserRepository.java
+++ b/src/main/java/bootcamp/kakao/community/platform/user/domain/repository/UserRepository.java
@@ -7,7 +7,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByEmail(String email);
+    /// 삭제되지않은 유저를 가져오고자 할 때,
+    Optional<User> findByEmailAndDeletedFalse(String email);
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/bootcamp/kakao/community/security/auth/application/AuthService.java
+++ b/src/main/java/bootcamp/kakao/community/security/auth/application/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService implements AuthUseCase {
     public JwtTokenResponse login(LoginRequest request, String deviceType) {
 
         /// DB 검증
-        User user = repository.findByEmail(request.email())
+        User user = repository.findByEmailAndDeletedFalse(request.email())
                 .orElseThrow(() -> new CustomException(SecurityErrorCode.NOT_FOUND_EMAIL));
 
         /// 패스워드 비교


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 회원가입 API 수정: 사용자 생성 시 이미지 URL 전달 추가
- 로그인 API 개선: 존재하지 않는 유저 조회 차단 로직 추가
- 전역 예외 핸들러 개선: 커스텀 에러 로깅 및 요청 BODY 타입 로깅 기능 추가
- 게시글 관련 리팩터링 브랜치와의 병합 처리 (feat/게시글-고도화 → refactor/이미지-...)

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 프론트엔드에서 회원가입 시 이미지 URL 필드 전달 확인 필요
- 로그인 API 동작 시 유저 존재 검증 로직 관련 테스트 필요

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#20 #32 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
