### PR TITLE
🔥 fix : 게시글 수정 로직

### DIFF
--- a/src/main/java/bootcamp/kakao/community/common/util/DateUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/util/DateUtil.java
@@ -16,8 +16,7 @@ public class DateUtil {
         } else if (duration.toHours() < 24) {
             return duration.toHours() + "시간 전";
         } else {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MMM dd일 HH시 ss분", Locale.KOREAN);
-
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MMM dd일 HH시 mm분", Locale.KOREAN);
             return created.format(formatter);
         }
     }

--- a/src/main/java/bootcamp/kakao/community/common/util/ImageUtil.java
+++ b/src/main/java/bootcamp/kakao/community/common/util/ImageUtil.java
@@ -21,13 +21,21 @@ public class ImageUtil {
         ImageUtil.region = region;
     }
 
+    /// Key 생성하는 함수
     public static String generateKey(String fileName) {
         String key = UUID.randomUUID().toString();
         String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
         return key + "." + extension;
     }
 
+    /// key를 URL로 만드는 함수
     public static String getUrlByKey(String key) {
+
+        /// null이면 없이 응답
+        if (key == null) {
+            return null;
+        }
+
         return "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + key;
     }
 }

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/PostImageService.java
@@ -86,7 +86,7 @@ public class PostImageService implements PostImageUseCase {
         if (!postImages.isEmpty()) {
             /// 존재한다면 저장 후,첫 이미지 URL 반환
             repository.saveAll(postImages);
-            return postImages.get(0).getImage().getKey();
+            return postImages.getFirst().getImage().getKey();
         }
 
         /// 없으면

--- a/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/dto/PostImageResponse.java
+++ b/src/main/java/bootcamp/kakao/community/platform/images/post_images/application/dto/PostImageResponse.java
@@ -12,6 +12,10 @@ import java.util.List;
 )
 @Builder
 public record PostImageResponse(
+
+        @Schema(description = "이미지 Key", example = "images/image1.png")
+        String imageKey,
+
         @Schema(description = "이미지 URL", example = "https://example.com/images/image1.png")
         String imageUrl,
 
@@ -23,6 +27,7 @@ public record PostImageResponse(
     public static PostImageResponse from(PostImage postImage) {
 
         return PostImageResponse.builder()
+                .imageKey(postImage.getImage().getKey())
                 .imageUrl(ImageUtil.getUrlByKey(postImage.getImage().getKey()))
                 .order(postImage.getOrd())
                 .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,7 @@ spring:
       port: 6379
 
   thymeleaf:
-    cache: false
+    cache: true
 
 # jwt
 auth:

--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -5,6 +5,8 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+        <!-- noIndex 설정 -->
+        <meta name="robots" content="noindex, nofollow">
         <link rel="stylesheet" th:href="@{/css/style.css}">
     </th:block>
 </head>


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 게시글 이미지 관련 기능 버그 수정 및 개선을 진행하였습니다.
- 게시글 이미지에 key 값을 추가하도록 PostImageResponse와 관련 서비스 로직 개선
- dto에 imageKey 필드 추가, 매핑 및 반환처리 반영
- 서비스 계층에 get(0) → getFirst()로 좀 더 안전히 첫 이미지 key 반환
- 게시글 작성일이 불명확하게 출력되는 오류 수정
- 이미지 URL이 없을 때에도 URL이 출력되는 문제 해결
- 타임리프 캐싱 ON 및 색인 방지 기능 적용

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 타임리프 캐싱 및 색인 방지를 통해 서비스 효율성과 보안이 함께 향상됩니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#51 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
