### PR TITLE
🔨chore : 배포 관련 디스코드 파이프라인

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -7,10 +7,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+
+    # 권한
+    permissions:
+      contents: write
+      checks: write
+      pull-requests: write
+
     outputs:
       passed: ${{ steps.parse.outputs.passed }}
       failed: ${{ steps.parse.outputs.failed }}
       total: ${{ steps.parse.outputs.total }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,11 +14,6 @@ jobs:
       checks: write
       pull-requests: write
 
-    outputs:
-      passed: ${{ steps.parse.outputs.passed }}
-      failed: ${{ steps.parse.outputs.failed }}
-      total: ${{ steps.parse.outputs.total }}
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -46,21 +41,10 @@ jobs:
           junit_files: '**/build/test-results/test/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test 결과 파싱
-        id: parse
-        run: |
-          PASSED=$(grep -o 'testsuite.*tests="[0-9]*"' -R build/test-results/test | sed 's/.*tests="\([0-9]*\)".*/\1/' | tr -d '[:space:]')
-          FAILED=$(grep -o 'failures="[0-9]*"' -R build/test-results/test | sed 's/.*failures="\([0-9]*\)".*/\1/' | tr -d '[:space:]')
-          TOTAL=$(( ${PASSED:-0} + ${FAILED:-0} ))
-          
-          echo "passed=${PASSED:-0}" >> $GITHUB_OUTPUT
-          echo "failed=${FAILED:-0}" >> $GITHUB_OUTPUT
-          echo "total=$TOTAL" >> $GITHUB_OUTPUT
-
   build:
     runs-on: ubuntu-22.04
     needs: test
-    if: needs.test.outputs.failed == '0'
+    if: success()
     steps:
       - uses: actions/checkout@v4
 
@@ -85,7 +69,7 @@ jobs:
 
   notify-discord:
     runs-on: ubuntu-22.04
-    needs: [test, build]
+    needs: build
     if: always()
     steps:
       - name: Discord 빌드 알림
@@ -101,11 +85,6 @@ jobs:
             **변경사항**:
             +${{ github.event.pull_request.additions }}
             -${{ github.event.pull_request.deletions }}
-
-            **🧪 테스트 결과**:
-            - 전체: **${{ needs.test.outputs.total }}**
-            - 통과: **${{ needs.test.outputs.passed }}**
-            - 실패: **${{ needs.test.outputs.failed }}**
 
             **📊 빌드 결과**:
             - 상태: ${{ needs.build.result == 'success' && '성공' || '실패' }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,12 +3,57 @@ name: 아무말 대잔치 테스트 PR CI 파이프라인
 on:
   pull_request:
     branches: ["develop"]
-    types:
-      - opened
+    types: [opened]
 
 jobs:
+  test:
+    runs-on: ubuntu-22.04
+    outputs:
+      passed: ${{ steps.parse.outputs.passed }}
+      failed: ${{ steps.parse.outputs.failed }}
+      total: ${{ steps.parse.outputs.total }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}
+
+      - name: 테스트 실행
+        run: |
+          ./gradlew test -Dspring.profiles.active=test || true
+
+      - name: Test 결과 업로드
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          junit_files: '**/build/test-results/test/TEST-*.xml'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test 결과 파싱
+        id: parse
+        run: |
+          PASSED=$(grep -o 'testsuite.*tests="[0-9]*"' -R build/test-results/test | sed 's/.*tests="\([0-9]*\)".*/\1/')
+          FAILED=$(grep -o 'failures="[0-9]*"' -R build/test-results/test | sed 's/.*failures="\([0-9]*\)".*/\1/')
+          TOTAL=$((PASSED + FAILED))
+
+          echo "passed=$PASSED" >> $GITHUB_OUTPUT
+          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+          echo "total=$TOTAL" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ubuntu-22.04
+    needs: test
+    if: needs.test.outputs.failed == '0'
     steps:
       - uses: actions/checkout@v4
 
@@ -29,32 +74,39 @@ jobs:
             gradle-${{ runner.os }}
 
       - name: 빌드하기
-        id: build
-        run: ./gradlew clean build -Dspring.profiles.active=prod
+        run: ./gradlew clean -x test build -Dspring.profiles.active=prod
 
   notify-discord:
     runs-on: ubuntu-22.04
-    needs: build
+    needs: [test, build]
     if: always()
     steps:
       - name: Discord 빌드 알림
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_BACK_URL }}
-          title: "${{ needs.build.result == 'success' && '✅' || '❌' }} Pull Request 리포트 - ${{ github.repository }}"
+          title: "${{ needs.build.result == 'success' && '✅' || '❌' }} 새로운 PR 리포트"
           description: |
             **제목**: ${{ github.event.pull_request.title }}
             **작성자**: ${{ github.event.pull_request.user.login }}
             **브랜치**: `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
-            **변경사항**: +${{ github.event.pull_request.additions }} -${{ github.event.pull_request.deletions }}
-            **커밋**: [`${{ github.event.pull_request.head.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }})
-            
+
+            **변경사항**:
+            <span style="color: green;">+${{ github.event.pull_request.additions }}</span>
+            <span style="color: red;">-${{ github.event.pull_request.deletions }}</span>
+
+            **🧪 테스트 결과**:
+            - 전체: **${{ needs.test.outputs.total }}**
+            - 통과: **${{ needs.test.outputs.passed }}**
+            - 실패: **${{ needs.test.outputs.failed }}**
+
             **📊 빌드 결과**:
             - 상태: ${{ needs.build.result == 'success' && '성공' || '실패' }}
             - 빌드 번호: ${{ github.run_number }}
-            
+
             **🔗 링크**:
             - [PR 확인하기](${{ github.event.pull_request.html_url }})
+
           color: "${{ needs.build.result == 'success' && 65280 || 16711680 }}"
-          username: GitHub Build Bot
-          avatar_url: https://github.githubassets.com/favicon.ico
+          username: GitHub PR Bot
+          avatar_url: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -76,15 +76,11 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_BACK_URL }}
-          title: "${{ needs.build.result == 'success' && '✅' || '❌' }} 새로운 PR 리포트"
+          title: "${{ needs.build.result == 'success' && '✅' || '❌' }} 새로운 PR이 올라왔습니다!"
           description: |
             **제목**: ${{ github.event.pull_request.title }}
             **작성자**: ${{ github.event.pull_request.user.login }}
-            **브랜치**: `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
-
-            **변경사항**:
-            +${{ github.event.pull_request.additions }}
-            -${{ github.event.pull_request.deletions }}
+            **브랜치**: `${{ github.event.pull_request.base.ref }}`←`${{ github.event.pull_request.head.ref }}`
 
             **📊 빌드 결과**:
             - 상태: ${{ needs.build.result == 'success' && '성공' || '실패' }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -91,8 +91,8 @@ jobs:
             **브랜치**: `${{ github.event.pull_request.head.ref }}` → `${{ github.event.pull_request.base.ref }}`
 
             **변경사항**:
-            <span style="color: green;">+${{ github.event.pull_request.additions }}</span>
-            <span style="color: red;">-${{ github.event.pull_request.deletions }}</span>
+            +${{ github.event.pull_request.additions }}
+            -${{ github.event.pull_request.deletions }}
 
             **🧪 테스트 결과**:
             - 전체: **${{ needs.test.outputs.total }}**

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,8 +2,7 @@ name: 아무말 대잔치 테스트 PR CI 파이프라인
 
 on:
   pull_request:
-    branches: ["develop"]
-    types: [opened]
+    branches: [ "develop"]
 
 jobs:
   test:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Test 결과 파싱
         id: parse
         run: |
-          PASSED=$(grep -o 'testsuite.*tests="[0-9]*"' -R build/test-results/test | sed 's/.*tests="\([0-9]*\)".*/\1/')
-          FAILED=$(grep -o 'failures="[0-9]*"' -R build/test-results/test | sed 's/.*failures="\([0-9]*\)".*/\1/')
-          TOTAL=$((PASSED + FAILED))
-
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+          PASSED=$(grep -o 'testsuite.*tests="[0-9]*"' -R build/test-results/test | sed 's/.*tests="\([0-9]*\)".*/\1/' | tr -d '[:space:]')
+          FAILED=$(grep -o 'failures="[0-9]*"' -R build/test-results/test | sed 's/.*failures="\([0-9]*\)".*/\1/' | tr -d '[:space:]')
+          TOTAL=$(( ${PASSED:-0} + ${FAILED:-0} ))
+          
+          echo "passed=${PASSED:-0}" >> $GITHUB_OUTPUT
+          echo "failed=${FAILED:-0}" >> $GITHUB_OUTPUT
           echo "total=$TOTAL" >> $GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,61 @@
+name: 아무말 대잔치 PROD 배포 파이프라인
+
+on:
+  release:
+    types: [published, prereleased]
+  deployment:
+    types: [created]
+  deployment_status:
+    types: [success, failure]
+
+jobs:
+  release-notification:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 릴리즈
+        if: github.event.action == 'published'
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_PROD }}
+          title: "🚀 새로운 릴리즈 발행!"
+          description: |
+            **버전**: [${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})
+            **제목**: ${{ github.event.release.name }}
+            **작성자**: ${{ github.event.release.author.login }}
+            **프리릴리즈**: ${{ github.event.release.prerelease && 'Yes' || 'No' }}
+
+            **📋 릴리즈 노트**:
+            ${{ github.event.release.body }}
+
+            **📦 다운로드**:
+            ${{ github.event.release.assets_url && format('[다운로드 링크]({0})', github.event.release.assets_url) || '다운로드 파일 없음' }}
+          color: ${{ github.event.release.prerelease && '0xffa500' || '0x28a745' }}
+          username: Release Bot
+
+      - name: 배포 성공
+        if: github.event.deployment_status.state == 'success'
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_PROD }}
+          title: "✅ 백엔드 배포 성공"
+          description: |
+            **환경**: ${{ github.event.deployment.environment }}
+            **커밋**: `${{ github.event.deployment.sha }}`
+            **배포 시간**: ${{ github.event.deployment_status.created_at }}
+
+            [배포 로그 확인](${{ github.event.deployment_status.target_url }})
+          color: 0x28a745
+
+      - name: 배포 실패
+        if: github.event.deployment_status.state == 'failure'
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URGENT }}
+          content: |
+            ❌ **백엔드 배포 실패** @channel
+
+            **환경**: ${{ github.event.deployment.environment }}
+            **오류 시간**: ${{ github.event.deployment_status.created_at }}
+            **로그**: ${{ github.event.deployment_status.target_url }}
+
+            즉시 확인 및 롤백이 필요합니다.

--- a/src/test/java/bootcamp/kakao/community/platform/user/application/UserServiceTest.java
+++ b/src/test/java/bootcamp/kakao/community/platform/user/application/UserServiceTest.java
@@ -1,0 +1,290 @@
+package bootcamp.kakao.community.platform.user.application;
+
+import bootcamp.kakao.community.common.response.CustomException;
+import bootcamp.kakao.community.common.response.code.UserErrorCode;
+import bootcamp.kakao.community.platform.user.application.dto.PwUpdateRequest;
+import bootcamp.kakao.community.platform.user.application.dto.SignUpRequest;
+import bootcamp.kakao.community.platform.user.application.dto.UserUpdateRequest;
+import bootcamp.kakao.community.platform.user.domain.entity.User;
+import bootcamp.kakao.community.platform.user.domain.entity.UserRole;
+import bootcamp.kakao.community.platform.user.domain.repository.UserRepository;
+import bootcamp.kakao.community.security.jwt.application.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 테스트")
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private ProfileImageUtil imageService;
+
+    @InjectMocks
+    private UserService userService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .name("홍길동")
+                .imageKey("test.jpg")
+                .nickname("길동이")
+                .email("hong@example.com")
+                .password("encodedPassword")
+                .role(UserRole.MEMBER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크 - 중복됨")
+    void checkDuplicateEmail_Exists() {
+        // given
+        String email = "hong@example.com";
+        given(userRepository.existsByEmail(email)).willReturn(true);
+
+        // when
+        boolean result = userService.checkDuplicateEmail(email);
+
+        // then
+        assertThat(result).isTrue();
+        verify(userRepository).existsByEmail(email);
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크 - 중복 안됨")
+    void checkDuplicateEmail_NotExists() {
+        // given
+        String email = "new@example.com";
+        given(userRepository.existsByEmail(email)).willReturn(false);
+
+        // when
+        boolean result = userService.checkDuplicateEmail(email);
+
+        // then
+        assertThat(result).isFalse();
+        verify(userRepository).existsByEmail(email);
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 체크 - 중복됨")
+    void checkDuplicateNickName_Exists() {
+        // given
+        String nickname = "길동이";
+        given(userRepository.existsByNickname(nickname)).willReturn(true);
+
+        // when
+        boolean result = userService.checkDuplicateNickName(nickname);
+
+        // then
+        assertThat(result).isTrue();
+        verify(userRepository).existsByNickname(nickname);
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 체크 - 중복 안됨")
+    void checkDuplicateNickName_NotExists() {
+        // given
+        String nickname = "새닉네임";
+        given(userRepository.existsByNickname(nickname)).willReturn(false);
+
+        // when
+        boolean result = userService.checkDuplicateNickName(nickname);
+
+        // then
+        assertThat(result).isFalse();
+        verify(userRepository).existsByNickname(nickname);
+    }
+
+    @Test
+    @DisplayName("회원가입 - 이메일 중복 시 예외 발생")
+    void signUp_DuplicateEmail_ThrowsException() {
+        // given
+        SignUpRequest request = new SignUpRequest(
+                "홍길동",
+                null,
+                "길동이",
+                "hong@example.com",
+                "password123",
+                "password123"
+        );
+        given(userRepository.existsByEmail(request.email())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.signUp(request, "web"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.CONFLICT_DUPLICATE_EMAIL);
+    }
+
+    @Test
+    @DisplayName("회원가입 - 닉네임 중복 시 예외 발생")
+    void signUp_DuplicateNickname_ThrowsException() {
+        // given
+        SignUpRequest request = new SignUpRequest(
+                "홍길동",
+                null,
+                "길동이",
+                "hong@example.com",
+                "password123",
+                "password123"
+        );
+        given(userRepository.existsByEmail(request.email())).willReturn(false);
+        given(userRepository.existsByNickname(request.nickname())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.signUp(request, "web"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.CONFLICT_DUPLICATE_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("회원가입 - 비밀번호 불일치 시 예외 발생")
+    void signUp_PasswordMismatch_ThrowsException() {
+        // given
+        SignUpRequest request = new SignUpRequest(
+                "홍길동",
+                null,
+                "길동이",
+                "hong@example.com",
+                "password123",
+                "password456"
+        );
+        given(userRepository.existsByEmail(request.email())).willReturn(false);
+        given(userRepository.existsByNickname(request.nickname())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> userService.signUp(request, "web"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.BAD_REQUEST_EQUAL_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 - 성공")
+    void withdraw_Success() {
+        // given
+        Long userId = 1L;
+        given(userRepository.findByIdAndDeletedIsFalse(userId)).willReturn(Optional.of(testUser));
+
+        // when
+        userService.withdraw(userId);
+
+        // then
+        assertThat(testUser.isDeleted()).isTrue();
+        verify(userRepository).findByIdAndDeletedIsFalse(userId);
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 - 존재하지 않는 유저")
+    void withdraw_UserNotFound_ThrowsException() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findByIdAndDeletedIsFalse(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.withdraw(userId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NOT_FOUND_USER);
+    }
+
+    @Test
+    @DisplayName("유저 정보 수정 - 닉네임 변경")
+    void updateUser_Nickname_Success() {
+        // given
+        Long userId = 1L;
+        UserUpdateRequest request = new UserUpdateRequest("새닉네임", null);
+        given(userRepository.findByIdAndDeletedIsFalse(userId)).willReturn(Optional.of(testUser));
+
+        // when
+        userService.updateUser(request, userId);
+
+        // then
+        assertThat(testUser.getNickname()).isEqualTo("새닉네임");
+        verify(userRepository).findByIdAndDeletedIsFalse(userId);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 기존 비밀번호 불일치 시 예외 발생")
+    void updatePassword_OldPasswordMismatch_ThrowsException() {
+        // given
+        Long userId = 1L;
+        PwUpdateRequest request = new PwUpdateRequest("wrongOldPassword", "newPassword123", "newPassword123");
+        given(userRepository.findByIdAndDeletedIsFalse(userId)).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches(request.oldPassword(), testUser.getPassword())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updatePassword(userId, request))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.BAD_REQUEST_OLD_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 새 비밀번호 불일치 시 예외 발생")
+    void updatePassword_NewPasswordMismatch_ThrowsException() {
+        // given
+        Long userId = 1L;
+        PwUpdateRequest request = new PwUpdateRequest("oldPassword", "newPassword123", "newPassword456");
+        given(userRepository.findByIdAndDeletedIsFalse(userId)).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches(request.oldPassword(), testUser.getPassword())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updatePassword(userId, request))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.BAD_REQUEST_EQUAL_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 성공")
+    void updatePassword_Success() {
+        // given
+        Long userId = 1L;
+        String oldPassword = "oldPassword";
+        String newPassword = "newPassword123";
+        PwUpdateRequest request = new PwUpdateRequest(oldPassword, newPassword, newPassword);
+
+        given(userRepository.findByIdAndDeletedIsFalse(userId)).willReturn(Optional.of(testUser));
+        given(passwordEncoder.matches(request.oldPassword(), testUser.getPassword())).willReturn(true);
+        given(passwordEncoder.encode(newPassword)).willReturn("encodedNewPassword");
+
+        // when
+        userService.updatePassword(userId, request);
+
+        // then
+        assertThat(testUser.getPassword()).isEqualTo("encodedNewPassword");
+        verify(passwordEncoder).encode(newPassword);
+    }
+
+    @Test
+    @DisplayName("유저 조회 - 존재하지 않는 유저")
+    void loadUser_NotFound_ThrowsException() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findByIdAndDeletedIsFalse(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.loadUser(userId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NOT_FOUND_USER);
+    }
+}

--- a/src/test/java/bootcamp/kakao/community/platform/user/domain/entity/UserTest.java
+++ b/src/test/java/bootcamp/kakao/community/platform/user/domain/entity/UserTest.java
@@ -1,0 +1,138 @@
+package bootcamp.kakao.community.platform.user.domain.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("User 엔티티 테스트")
+class UserTest {
+
+    @Test
+    @DisplayName("User 생성 - 정적 팩토리 메서드")
+    void createUser() {
+        // given
+        String name = "홍길동";
+        String imageKey = "profile.jpg";
+        String nickname = "길동이";
+        String email = "hong@example.com";
+        String password = "password123";
+
+        // when
+        User user = User.of(name, imageKey, nickname, email, password);
+
+        // then
+        assertThat(user).isNotNull();
+        assertThat(user.getName()).isEqualTo(name);
+        assertThat(user.getImageKey()).isEqualTo(imageKey);
+        assertThat(user.getNickname()).isEqualTo(nickname);
+        assertThat(user.getEmail()).isEqualTo(email);
+        assertThat(user.getPassword()).isEqualTo(password);
+        assertThat(user.getRole()).isEqualTo(UserRole.MEMBER);
+        assertThat(user.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("User 생성 - 빌더 패턴")
+    void createUserWithBuilder() {
+        // given & when
+        User user = User.builder()
+                .name("김철수")
+                .imageKey("image.jpg")
+                .nickname("철수")
+                .email("kim@example.com")
+                .password("pass1234")
+                .role(UserRole.ADMIN)
+                .build();
+
+        // then
+        assertThat(user).isNotNull();
+        assertThat(user.getName()).isEqualTo("김철수");
+        assertThat(user.getRole()).isEqualTo(UserRole.ADMIN);
+        assertThat(user.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("User 삭제 - delete 메서드 호출")
+    void deleteUser() {
+        // given
+        User user = User.of("홍길동", null, "길동이", "hong@example.com", "password123");
+        assertThat(user.isDeleted()).isFalse();
+
+        // when
+        user.delete();
+
+        // then
+        assertThat(user.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("User 이미지 업데이트")
+    void updateImage() {
+        // given
+        User user = User.of("홍길동", "old.jpg", "길동이", "hong@example.com", "password123");
+        String newImageKey = "new.jpg";
+
+        // when
+        user.updateImage(newImageKey);
+
+        // then
+        assertThat(user.getImageKey()).isEqualTo(newImageKey);
+    }
+
+    @Test
+    @DisplayName("User 이미지 업데이트 - null인 경우 변경하지 않음")
+    void updateImageWithNull() {
+        // given
+        User user = User.of("홍길동", "old.jpg", "길동이", "hong@example.com", "password123");
+        String originalImageKey = user.getImageKey();
+
+        // when
+        user.updateImage(null);
+
+        // then
+        assertThat(user.getImageKey()).isEqualTo(originalImageKey);
+    }
+
+    @Test
+    @DisplayName("User 닉네임 업데이트")
+    void updateNickname() {
+        // given
+        User user = User.of("홍길동", null, "길동이", "hong@example.com", "password123");
+        String newNickname = "새닉네임";
+
+        // when
+        user.updateNickname(newNickname);
+
+        // then
+        assertThat(user.getNickname()).isEqualTo(newNickname);
+    }
+
+    @Test
+    @DisplayName("User 닉네임 업데이트 - null인 경우 변경하지 않음")
+    void updateNicknameWithNull() {
+        // given
+        User user = User.of("홍길동", null, "길동이", "hong@example.com", "password123");
+        String originalNickname = user.getNickname();
+
+        // when
+        user.updateNickname(null);
+
+        // then
+        assertThat(user.getNickname()).isEqualTo(originalNickname);
+    }
+
+    @Test
+    @DisplayName("User 비밀번호 업데이트")
+    void updatePassword() {
+        // given
+        User user = User.of("홍길동", null, "길동이", "hong@example.com", "password123");
+        String newPassword = "newPassword456";
+
+        // when
+        user.updatePassword(newPassword);
+
+        // then
+        assertThat(user.getPassword()).isEqualTo(newPassword);
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 백엔드 배포와 관련된 디스코드 알림 파이프라인을 설정했습니다.
- 릴리즈가 발행되면 디스코드에 새로운 릴리즈 정보가 공지됩니다.
- 배포가 성공하면 성공 메시지, 실패 시 긴급 실패 메시지를 각각 다른 디스코드 웹훅으로 전송하도록 구현했습니다.
- GitHub Actions 워크플로우 파일(.github/workflows/deployment.yml)에 61줄을 추가하여 배포 관련 알림 파이프라인을 완성했습니다.

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 배포 성공과 실패 알림을 위한 조건 구문을 사용하여 상황별로 다른 메시지가 전송됩니다.
- 릴리즈 정보에는 버전, 제목, 작성자, 프리릴리즈 여부, 릴리즈 노트, 다운로드 링크 등이 포함됩니다.
- 배포 상태 알림에는 환경, 커밋 SHA, 배포 시간, 배포 로그 확인 링크가 포함됩니다.
- 배포 실패 시 긴급 알림을 위해 별도의 웹훅과 @channel 멘션이 사용됩니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
#53 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
